### PR TITLE
fix: correct parameter names in findByIdAndUserId

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -195,6 +195,12 @@
             <artifactId>flyway-database-postgresql</artifactId>
         </dependency>
 
+        <!-- Reactive Redis for session caching -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis-reactive</artifactId>
+        </dependency>
+
         <!-- ========================= -->
         <!-- Spring AI 2.0             -->
         <!-- ========================= -->

--- a/server/src/main/java/ai/jarvis/ai/orchestrator/AiOrchestrator.java
+++ b/server/src/main/java/ai/jarvis/ai/orchestrator/AiOrchestrator.java
@@ -5,8 +5,8 @@ import ai.jarvis.ai.prompt.WorkingMemoryBuilder;
 import ai.jarvis.ai.provider.AiProvider;
 import ai.jarvis.ai.provider.ProviderRouter;
 import ai.jarvis.chat.message.Message;
-import ai.jarvis.chat.message.MessageRepository;
 import ai.jarvis.chat.session.ChatSessionRepository;
+import ai.jarvis.memory.session.SessionMemoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -26,11 +25,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class AiOrchestrator {
 
     private final ProviderRouter providerRouter;
-    private final MessageRepository messageRepository;
     private final ChatSessionRepository sessionRepository;
     private final R2dbcEntityTemplate r2dbcEntityTemplate;
     private final PromptAssembler promptAssembler;
     private final WorkingMemoryBuilder workingMemoryBuilder;
+    private final SessionMemoryService sessionMemoryService;
 
     public Flux<String> chat(OrchestratorRequest request) {
 
@@ -44,13 +43,11 @@ public class AiOrchestrator {
 
         return r2dbcEntityTemplate
                 .insert(userMsg)
-                .then(messageRepository
-                        .findBySessionIdOrderByCreatedAtAsc(
-                                request.sessionId())
-                        .collectList()
-                )
+                // .then() closes immediately after loadHistory()
+                // NOT wrapping the entire downstream chain
+                .then(sessionMemoryService.loadHistory(
+                        request.sessionId()))
                 .flatMap(history ->
-                        // Route to best provider first
                         providerRouter.route()
                                 .map(provider ->
                                         new ProviderAndHistory(
@@ -73,18 +70,16 @@ public class AiOrchestrator {
                     List<Message> historyWithoutCurrent =
                             history.subList(
                                     0,
-                                    Math.max(
-                                            0,
+                                    Math.max(0,
                                             history.size() - 1)
                             );
 
-                    Prompt prompt = promptAssembler
-                            .assemble(
-                                    request.message(),
-                                    workingMemory,
-                                    historyWithoutCurrent,
-                                    request.username()
-                            );
+                    Prompt prompt = promptAssembler.assemble(
+                            request.message(),
+                            workingMemory,
+                            historyWithoutCurrent,
+                            request.username()
+                    );
 
                     StringBuilder responseBuilder =
                             new StringBuilder();
@@ -92,9 +87,8 @@ public class AiOrchestrator {
                             new AtomicInteger(0);
 
                     log.info(
-                            "AI request: user={} "
-                                    + "session={} provider={} "
-                                    + "model={} history={}",
+                            "AI request: user={} session={} "
+                                    + "provider={} model={} history={}",
                             request.username(),
                             request.sessionId(),
                             provider.getName(),
@@ -104,10 +98,8 @@ public class AiOrchestrator {
 
                     return provider.streamChat(prompt)
                             .doOnNext(token -> {
-                                responseBuilder
-                                        .append(token);
-                                tokenCount
-                                        .incrementAndGet();
+                                responseBuilder.append(token);
+                                tokenCount.incrementAndGet();
                             })
                             .doOnComplete(() -> {
                                 long duration =
@@ -115,9 +107,8 @@ public class AiOrchestrator {
                                                 - startTime;
 
                                 log.info(
-                                        "AI response: "
-                                                + "user={} tokens≈{} "
-                                                + "duration={}ms "
+                                        "AI response: user={} "
+                                                + "tokens≈{} duration={}ms "
                                                 + "provider={}",
                                         request.username(),
                                         tokenCount.get(),
@@ -127,8 +118,7 @@ public class AiOrchestrator {
 
                                 saveAssistantMessage(
                                         request.sessionId(),
-                                        responseBuilder
-                                                .toString(),
+                                        responseBuilder.toString(),
                                         tokenCount.get(),
                                         (int) duration,
                                         provider.getModelName()
@@ -136,10 +126,8 @@ public class AiOrchestrator {
                             })
                             .doOnError(error -> {
                                 log.error(
-                                        "AI error: "
-                                                + "user={} "
-                                                + "provider={} "
-                                                + "error={}",
+                                        "AI error: user={} "
+                                                + "provider={} error={}",
                                         request.username(),
                                         provider.getName(),
                                         error.getMessage()
@@ -149,7 +137,12 @@ public class AiOrchestrator {
                                         error.getMessage()
                                 ).subscribe();
                             });
-                });
+                })
+                .doFinally(signal ->
+                        sessionMemoryService
+                                .onMessageSaved(request.sessionId())
+                                .subscribe()
+                );
     }
 
     // ── Private helpers ───────────────────────────
@@ -173,15 +166,24 @@ public class AiOrchestrator {
 
         return r2dbcEntityTemplate
                 .insert(assistantMsg)
-                .then(sessionRepository
-                        .incrementMessageCount(
-                                sessionId, tokens))
+                .flatMap(saved -> {
+                    log.debug("Assistant message saved: {}",
+                            saved.id());
+                    return sessionRepository
+                            .incrementMessageCount(
+                                    sessionId, tokens)
+                            .then();
+                })
+                .doOnError(error ->
+                        log.error(
+                                "Failed to save assistant message: {}",
+                                error.getMessage(), error)
+                )
                 .then();
     }
 
     private Mono<Void> saveErrorMessage(
-            UUID sessionId,
-            String errorText) {
+            UUID sessionId, String errorText) {
         Message errorMsg = Message.errorMessage(
                 UUID.randomUUID(),
                 sessionId,
@@ -191,8 +193,6 @@ public class AiOrchestrator {
                 .insert(errorMsg)
                 .then();
     }
-
-    // ── Private record ────────────────────────────
 
     private record ProviderAndHistory(
             AiProvider provider,

--- a/server/src/main/java/ai/jarvis/ai/orchestrator/AiOrchestrator.java
+++ b/server/src/main/java/ai/jarvis/ai/orchestrator/AiOrchestrator.java
@@ -35,16 +35,20 @@ public class AiOrchestrator {
 
         long startTime = System.currentTimeMillis();
 
+        // Generate ID first so we can exclude it
+        // from history when building the prompt
+        UUID userMsgId = UUID.randomUUID();
+
         Message userMsg = Message.userMessage(
-                UUID.randomUUID(),
+                userMsgId,
                 request.sessionId(),
                 request.message()
         );
 
         return r2dbcEntityTemplate
                 .insert(userMsg)
-                // .then() closes immediately after loadHistory()
-                // NOT wrapping the entire downstream chain
+                // Load history AFTER insert
+                // SessionMemoryService: Redis first, DB fallback
                 .then(sessionMemoryService.loadHistory(
                         request.sessionId()))
                 .flatMap(history ->
@@ -67,12 +71,16 @@ public class AiOrchestrator {
                                     provider.getModelName()
                             );
 
+                    // filter by ID instead of tail trim.
+                    // Tail trim breaks on Redis cache HIT because
+                    // the cached list may not include the new user
+                    // message yet. Filtering by ID works correctly
+                    // for both cache HIT and cache MISS.
                     List<Message> historyWithoutCurrent =
-                            history.subList(
-                                    0,
-                                    Math.max(0,
-                                            history.size() - 1)
-                            );
+                            history.stream()
+                                    .filter(msg -> !msg.id()
+                                            .equals(userMsgId))
+                                    .toList();
 
                     Prompt prompt = promptAssembler.assemble(
                             request.message(),
@@ -116,13 +124,19 @@ public class AiOrchestrator {
                                         provider.getName()
                                 );
 
+                                // Save async — does not block stream
                                 saveAssistantMessage(
                                         request.sessionId(),
                                         responseBuilder.toString(),
                                         tokenCount.get(),
                                         (int) duration,
                                         provider.getModelName()
-                                ).subscribe();
+                                )
+                                        .doOnError(e ->
+                                                log.error(
+                                                        "Save assistant failed: {}",
+                                                        e.getMessage()))
+                                        .subscribe();
                             })
                             .doOnError(error -> {
                                 log.error(
@@ -139,8 +153,14 @@ public class AiOrchestrator {
                             });
                 })
                 .doFinally(signal ->
+                        // Refresh cache after exchange completes
+                        // so next request gets updated history
                         sessionMemoryService
                                 .onMessageSaved(request.sessionId())
+                                .doOnError(e ->
+                                        log.warn(
+                                                "Cache refresh failed: {}",
+                                                e.getMessage()))
                                 .subscribe()
                 );
     }
@@ -166,19 +186,30 @@ public class AiOrchestrator {
 
         return r2dbcEntityTemplate
                 .insert(assistantMsg)
-                .flatMap(saved -> {
-                    log.debug("Assistant message saved: {}",
-                            saved.id());
-                    return sessionRepository
-                            .incrementMessageCount(
-                                    sessionId, tokens)
-                            .then();
-                })
+                .doOnSuccess(saved ->
+                        log.debug("Assistant saved: {}",
+                                saved.id()))
+                .flatMap(saved ->
+                        sessionRepository
+                                .incrementMessageCount(
+                                        sessionId, tokens)
+                                .doOnSuccess(rows ->
+                                        log.debug(
+                                                "Session updated: rows={}",
+                                                rows))
+                                .doOnError(error ->
+                                        log.error(
+                                                "incrementMessageCount "
+                                                        + "failed [{}]: {}",
+                                                sessionId,
+                                                error.getMessage()))
+                )
                 .doOnError(error ->
                         log.error(
-                                "Failed to save assistant message: {}",
-                                error.getMessage(), error)
-                )
+                                "saveAssistantMessage "
+                                        + "failed [{}]: {}",
+                                sessionId,
+                                error.getMessage(), error))
                 .then();
     }
 
@@ -191,8 +222,14 @@ public class AiOrchestrator {
         );
         return r2dbcEntityTemplate
                 .insert(errorMsg)
+                .doOnError(e ->
+                        log.error(
+                                "saveErrorMessage failed: {}",
+                                e.getMessage()))
                 .then();
     }
+
+    // ── Private record ────────────────────────────
 
     private record ProviderAndHistory(
             AiProvider provider,

--- a/server/src/main/java/ai/jarvis/chat/message/MessageRepository.java
+++ b/server/src/main/java/ai/jarvis/chat/message/MessageRepository.java
@@ -1,5 +1,6 @@
 package ai.jarvis.chat.message;
 
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
@@ -11,18 +12,27 @@ import java.util.UUID;
 public interface MessageRepository
         extends R2dbcRepository<Message, UUID> {
 
-    // Load all messages for a session (chronological order)
-    // This is the MOST IMPORTANT query — runs on every chat load
-    Flux<Message> findBySessionIdOrderByCreatedAtAsc(UUID sessionId);
-
-    // Load last N messages (for context window management)
-    Flux<Message> findTop20BySessionIdOrderByCreatedAtDesc(
+    // Full history (ascending) — for display
+    Flux<Message> findBySessionIdOrderByCreatedAtAsc(
             UUID sessionId);
 
-    // Count messages in a session
+    // Last N messages at DB level — for prompt context
+    // Fetches newest N rows, reverses for ascending order
+    @Query("""
+            SELECT * FROM (
+                SELECT * FROM messages
+                WHERE session_id = :sessionId
+                ORDER BY created_at DESC
+                LIMIT :limit
+            ) sub
+            ORDER BY created_at ASC
+            """)
+    Flux<Message> findLastNBySessionId(
+            UUID sessionId, int limit);
+
     Mono<Long> countBySessionId(UUID sessionId);
 
-    // Get only user + assistant messages (not system)
     Flux<Message> findBySessionIdAndRoleInOrderByCreatedAtAsc(
-            UUID sessionId, java.util.List<MessageRole> roles);
+            UUID sessionId,
+            java.util.List<MessageRole> roles);
 }

--- a/server/src/main/java/ai/jarvis/chat/session/ChatSessionRepository.java
+++ b/server/src/main/java/ai/jarvis/chat/session/ChatSessionRepository.java
@@ -12,29 +12,25 @@ import java.util.UUID;
 public interface ChatSessionRepository
         extends R2dbcRepository<ChatSession, UUID> {
 
-    // Find all active sessions for a user
-    // ordered by most recent message first
     Flux<ChatSession> findByUserIdAndStatusOrderByLastMessageAtDesc(
             UUID userId, String status);
 
-    // Find a specific session that belongs to a user
-    Mono<ChatSession> findByIdAndUserId(UUID userId, UUID sessionId);
+    Mono<ChatSession> findByIdAndUserId(
+            UUID id, UUID userId);
 
-    // Count sessions for a user
     Mono<Long> countByUserId(UUID userId);
 
-    // Update message count and tokens after a chat
     @Query("""
             UPDATE chat_sessions
-            SET message_count = message_count +1,
+            SET message_count = message_count + 1,
                 total_tokens = total_tokens + :tokens,
                 last_message_at = NOW(),
                 updated_at = NOW()
-            where id = :sessionId
+            WHERE id = :sessionId
             """)
-    Mono<Void> incrementMessageCount(UUID sessionId, int tokens);
+    Mono<Integer> incrementMessageCount(
+            UUID sessionId, int tokens);
 
-    // Auto-generate title from first message
     @Query("""
             UPDATE chat_sessions
             SET title = :title,

--- a/server/src/main/java/ai/jarvis/chat/streaming/ChatStreamController.java
+++ b/server/src/main/java/ai/jarvis/chat/streaming/ChatStreamController.java
@@ -51,11 +51,10 @@ public class ChatStreamController {
                 .map(SecurityContext::getAuthentication)
                 .flatMapMany(auth -> {
 
-                    // Extract BOTH userId and username
-                    // from the security context
                     String userId = auth.getPrincipal()
                             .toString();
-                    String username = extractUsername(auth);
+                    String username =
+                            extractUsername(auth);
 
                     return resolveSession(
                             request.sessionId(),
@@ -65,35 +64,40 @@ public class ChatStreamController {
                             .flatMapMany(session -> {
 
                                 log.info(
-                                        "Chat: user={} sessionId={}",
-                                        username, session.id()
-                                );
+                                        "Chat: user={} session={}",
+                                        username, session.id());
 
                                 OrchestratorRequest orchRequest =
                                         OrchestratorRequest.of(
                                                 session.id(),
                                                 request.message(),
-                                                username, // ← REAL username
+                                                username,
                                                 extractRole(auth)
                                         );
 
                                 return orchestrator
                                         .chat(orchRequest)
                                         .map(token ->
-                                                ServerSentEvent.<String>builder()
+                                                ServerSentEvent
+                                                        .<String>builder()
                                                         .event("token")
                                                         .data(jsonToken(token))
                                                         .build()
                                         )
-                                        //  PREPEND session event BEFORE tokens
+                                        // Send session ID FIRST
+                                        // CLI stores this for
+                                        // next message continuity
                                         .startWith(
-                                                ServerSentEvent.<String>builder()
+                                                ServerSentEvent
+                                                        .<String>builder()
                                                         .event("session")
-                                                        .data(session.id().toString())
+                                                        .data(session.id()
+                                                                .toString())
                                                         .build()
                                         )
                                         .concatWith(Flux.just(
-                                                ServerSentEvent.<String>builder()
+                                                ServerSentEvent
+                                                        .<String>builder()
                                                         .event("done")
                                                         .data("[DONE]")
                                                         .build()
@@ -102,17 +106,7 @@ public class ChatStreamController {
                 });
     }
 
-    /**
-     * Wrap token in JSON to preserve spaces.
-     *
-     * Problem: SSE codec strips leading whitespace.
-     * " nice" → becomes "nice" after SSE parsing.
-     *
-     * Solution: {"t":" nice"} → JSON string preserves
-     * the space inside the JSON value.
-     */
     private String jsonToken(String token) {
-        // Simple JSON encoding - escape special chars
         return "{\"t\":\""
                 + token
                 .replace("\\", "\\\\")
@@ -123,12 +117,8 @@ public class ChatStreamController {
     }
 
     private String extractUsername(Authentication auth) {
-        // Details holds username (set in JWT filter)
         Object details = auth.getDetails();
-        if (details instanceof String s) {
-            return s;
-        }
-        // Fallback to principal if details not set
+        if (details instanceof String s) return s;
         return auth.getPrincipal().toString();
     }
 
@@ -167,8 +157,7 @@ public class ChatStreamController {
                 .insert(newSession)
                 .flatMap(saved ->
                         sessionRepository
-                                .setTitleIfNull(
-                                        saved.id(), title)
+                                .setTitleIfNull(saved.id(), title)
                                 .thenReturn(saved)
                 );
     }

--- a/server/src/main/java/ai/jarvis/config/JacksonConfig.java
+++ b/server/src/main/java/ai/jarvis/config/JacksonConfig.java
@@ -1,0 +1,20 @@
+package ai.jarvis.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean("jarvisObjectMapper")    // ← named, NOT @Primary
+    public ObjectMapper jarvisObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(
+                SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
+}

--- a/server/src/main/java/ai/jarvis/memory/session/SessionCacheService.java
+++ b/server/src/main/java/ai/jarvis/memory/session/SessionCacheService.java
@@ -3,6 +3,8 @@ package ai.jarvis.memory.session;
 import ai.jarvis.chat.message.Message;
 import ai.jarvis.chat.message.MessageRepository;
 import ai.jarvis.chat.message.MessageRole;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
@@ -12,9 +14,22 @@ import reactor.core.publisher.Mono;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Caches session message history in Redis.
+ *
+ * ENCODING: JSON Lines (one JSON object per line).
+ * Each line: {"r":"ROLE","i":"uuid","c":"content"}
+ *
+ * WHY JSON Lines instead of custom escaping:
+ * - Jackson handles all special chars correctly
+ * - No data corruption for code, JSON, Windows paths
+ * - Safe round-trip for any message content
+ * - Still simple to parse (one object per line)
+ */
 @Slf4j
 @Service
 public class SessionCacheService {
@@ -22,28 +37,30 @@ public class SessionCacheService {
     private final ReactiveRedisTemplate<String, String>
             redisTemplate;
     private final MessageRepository messageRepository;
+    private final ObjectMapper objectMapper;
 
     private static final Duration SESSION_TTL =
             Duration.ofHours(1);
     private static final String MESSAGES_PREFIX =
             "session:messages:";
     private static final int MAX_MESSAGES = 20;
-    private static final String SEPARATOR = "|";
-    private static final String LINE_SEP = "\n";
 
     public SessionCacheService(
             @Qualifier("reactiveStringRedisTemplate")
             ReactiveRedisTemplate<String, String>
                     redisTemplate,
-            MessageRepository messageRepository) {
+            MessageRepository messageRepository,
+            @Qualifier("jarvisObjectMapper")
+            ObjectMapper objectMapper) {
         this.redisTemplate = redisTemplate;
         this.messageRepository = messageRepository;
+        this.objectMapper = objectMapper;
     }
 
     /**
-     * Get session history from Redis or PostgreSQL.
-     * Cache HIT  → Redis   (~1ms)
-     * Cache MISS → PostgreSQL (~50ms) then cached
+     * Get session history.
+     * Cache HIT → Redis (~1ms)
+     * Cache MISS → PostgreSQL last 20 rows + cache
      */
     public Mono<List<Message>> getSessionHistory(
             UUID sessionId) {
@@ -54,7 +71,6 @@ public class SessionCacheService {
                 .get(key)
                 .flatMap(cached -> {
                     log.debug("Cache HIT: {}", sessionId);
-                    // Extend TTL on access
                     return redisTemplate
                             .expire(key, SESSION_TTL)
                             .thenReturn(
@@ -66,16 +82,16 @@ public class SessionCacheService {
                 )
                 .onErrorResume(error -> {
                     log.warn(
-                            "Redis error, using DB: {}",
-                            error.getMessage());
+                            "Redis error [{}], using DB: {}",
+                            sessionId,
+                            error.getClass().getSimpleName());
                     return loadFromDb(sessionId);
                 });
     }
 
     /**
-     * Refresh cache after new message saved.
-     * Reloads fresh data from DB and re-caches.
-     * Does NOT delete — just refreshes.
+     * Refresh cache after message saved.
+     * Reloads from DB and re-caches.
      */
     public Mono<Void> refreshCache(UUID sessionId) {
         String key = MESSAGES_PREFIX + sessionId;
@@ -90,7 +106,6 @@ public class SessionCacheService {
 
     /**
      * Hard invalidate — only when session deleted.
-     * NOT called after every message anymore.
      */
     public Mono<Void> invalidate(UUID sessionId) {
         return redisTemplate
@@ -112,81 +127,113 @@ public class SessionCacheService {
                 );
     }
 
+    /**
+     * Load last MAX_MESSAGES from DB at query level.
+     * No in-memory slicing needed.
+     */
     private Mono<List<Message>> loadFromDb(
             UUID sessionId) {
-        log.debug("Cache MISS: {} — DB query",
+        log.debug("Cache MISS [{}] — DB query",
                 sessionId);
+        // LIMIT pushed to DB query
         return messageRepository
-                .findBySessionIdOrderByCreatedAtAsc(
-                        sessionId)
-                .collectList()
-                .map(messages -> {
-                    if (messages.size() > MAX_MESSAGES) {
-                        return messages.subList(
-                                messages.size()
-                                        - MAX_MESSAGES,
-                                messages.size());
-                    }
-                    return messages;
-                });
+                .findLastNBySessionId(
+                        sessionId, MAX_MESSAGES)
+                .collectList();
     }
 
     private Mono<Void> cacheMessages(
             String key, List<Message> messages) {
-        String serialized = serialize(messages);
-        return redisTemplate.opsForValue()
-                .set(key, serialized, SESSION_TTL)
-                .doOnSuccess(ok ->
-                        log.debug(
-                                "Cached {} msgs: {}",
-                                messages.size(), key))
-                .then();
+        try {
+            String serialized = serialize(messages);
+            return redisTemplate.opsForValue()
+                    .set(key, serialized, SESSION_TTL)
+                    .doOnSuccess(ok ->
+                            log.debug(
+                                    "Cached {} msgs [{}]",
+                                    messages.size(), key))
+                    .then();
+        } catch (Exception e) {
+            log.error(
+                    "Cache write failed [{}]: {}",
+                    key, e.getClass().getSimpleName());
+            return Mono.empty();
+        }
     }
 
-    private String serialize(List<Message> messages) {
+    /**
+     * Serialize as JSON Lines.
+     * Each line = one MessageDto JSON object.
+     * Jackson handles all special chars correctly.
+     */
+    private String serialize(
+            List<Message> messages) throws Exception {
         StringBuilder sb = new StringBuilder();
         for (Message msg : messages) {
             if (msg.role() == null) continue;
             if (msg.content() == null) continue;
-            sb.append(msg.role().name())
-                    .append(SEPARATOR)
-                    .append(msg.id().toString())
-                    .append(SEPARATOR)
-                    .append(msg.content()
-                            .replace("\n", "\\n"))
-                    .append(LINE_SEP);
+            MessageDto dto = new MessageDto(
+                    msg.role().name(),
+                    msg.id().toString(),
+                    msg.content()
+            );
+            sb.append(objectMapper.writeValueAsString(dto))
+                    .append("\n");
         }
         return sb.toString();
     }
 
+    /**
+     * Deserialize JSON Lines back to Message list.
+     * Fix: logs session ID only, NOT message content.
+     */
     private List<Message> deserialize(
             String data, UUID sessionId) {
         List<Message> messages = new ArrayList<>();
         if (data == null || data.isBlank()) {
             return messages;
         }
-        String[] lines = data.split(LINE_SEP);
+
+        String[] lines = data.split("\n");
+        int lineNum = 0;
         for (String line : lines) {
+            lineNum++;
             if (line.isBlank()) continue;
-            String[] parts = line.split(
-                    "\\" + SEPARATOR, 3);
-            if (parts.length < 3) continue;
             try {
+                MessageDto dto = objectMapper
+                        .readValue(line,
+                                MessageDto.class);
                 MessageRole role = MessageRole
-                        .valueOf(parts[0].trim());
-                UUID id = UUID.fromString(
-                        parts[1].trim());
-                String content = parts[2]
-                        .replace("\\n", "\n");
+                        .valueOf(dto.r());
+                UUID id = UUID.fromString(dto.i());
+
                 messages.add(new Message(
-                        id, sessionId, role, content,
+                        id, sessionId, role, dto.c(),
                         null, null, null, null, null,
                         null, null, false, null,
                         Instant.now()));
+
             } catch (Exception e) {
-                log.warn("Skip line: {}", line);
+                // Fix: log session ID + line number only
+                // NOT the line content (may contain user text)
+                log.warn(
+                        "Parse failed session={} line={}: {}",
+                        sessionId, lineNum,
+                        e.getClass().getSimpleName());
             }
         }
         return messages;
     }
+
+    // ── DTO for Redis serialization ────────────────
+
+    /**
+     * Minimal DTO for Redis storage.
+     * Short field names to reduce Redis memory usage.
+     * r = role, i = id, c = content
+     */
+    private record MessageDto(
+            @JsonProperty("r") String r,
+            @JsonProperty("i") String i,
+            @JsonProperty("c") String c) {}
 }

--- a/server/src/main/java/ai/jarvis/memory/session/SessionCacheService.java
+++ b/server/src/main/java/ai/jarvis/memory/session/SessionCacheService.java
@@ -1,0 +1,192 @@
+package ai.jarvis.memory.session;
+
+import ai.jarvis.chat.message.Message;
+import ai.jarvis.chat.message.MessageRepository;
+import ai.jarvis.chat.message.MessageRole;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class SessionCacheService {
+
+    private final ReactiveRedisTemplate<String, String>
+            redisTemplate;
+    private final MessageRepository messageRepository;
+
+    private static final Duration SESSION_TTL =
+            Duration.ofHours(1);
+    private static final String MESSAGES_PREFIX =
+            "session:messages:";
+    private static final int MAX_MESSAGES = 20;
+    private static final String SEPARATOR = "|";
+    private static final String LINE_SEP = "\n";
+
+    public SessionCacheService(
+            @Qualifier("reactiveStringRedisTemplate")
+            ReactiveRedisTemplate<String, String>
+                    redisTemplate,
+            MessageRepository messageRepository) {
+        this.redisTemplate = redisTemplate;
+        this.messageRepository = messageRepository;
+    }
+
+    /**
+     * Get session history from Redis or PostgreSQL.
+     * Cache HIT  → Redis   (~1ms)
+     * Cache MISS → PostgreSQL (~50ms) then cached
+     */
+    public Mono<List<Message>> getSessionHistory(
+            UUID sessionId) {
+
+        String key = MESSAGES_PREFIX + sessionId;
+
+        return redisTemplate.opsForValue()
+                .get(key)
+                .flatMap(cached -> {
+                    log.debug("Cache HIT: {}", sessionId);
+                    // Extend TTL on access
+                    return redisTemplate
+                            .expire(key, SESSION_TTL)
+                            .thenReturn(
+                                    deserialize(cached,
+                                            sessionId));
+                })
+                .switchIfEmpty(
+                        loadAndCache(sessionId, key)
+                )
+                .onErrorResume(error -> {
+                    log.warn(
+                            "Redis error, using DB: {}",
+                            error.getMessage());
+                    return loadFromDb(sessionId);
+                });
+    }
+
+    /**
+     * Refresh cache after new message saved.
+     * Reloads fresh data from DB and re-caches.
+     * Does NOT delete — just refreshes.
+     */
+    public Mono<Void> refreshCache(UUID sessionId) {
+        String key = MESSAGES_PREFIX + sessionId;
+        return loadFromDb(sessionId)
+                .flatMap(messages ->
+                        cacheMessages(key, messages))
+                .doOnSuccess(v ->
+                        log.debug("Cache refreshed: {}",
+                                sessionId))
+                .then();
+    }
+
+    /**
+     * Hard invalidate — only when session deleted.
+     * NOT called after every message anymore.
+     */
+    public Mono<Void> invalidate(UUID sessionId) {
+        return redisTemplate
+                .delete(MESSAGES_PREFIX + sessionId)
+                .doOnSuccess(d ->
+                        log.debug("Cache deleted: {}",
+                                sessionId))
+                .then();
+    }
+
+    // ── Private ───────────────────────────────────
+
+    private Mono<List<Message>> loadAndCache(
+            UUID sessionId, String key) {
+        return loadFromDb(sessionId)
+                .flatMap(messages ->
+                        cacheMessages(key, messages)
+                                .thenReturn(messages)
+                );
+    }
+
+    private Mono<List<Message>> loadFromDb(
+            UUID sessionId) {
+        log.debug("Cache MISS: {} — DB query",
+                sessionId);
+        return messageRepository
+                .findBySessionIdOrderByCreatedAtAsc(
+                        sessionId)
+                .collectList()
+                .map(messages -> {
+                    if (messages.size() > MAX_MESSAGES) {
+                        return messages.subList(
+                                messages.size()
+                                        - MAX_MESSAGES,
+                                messages.size());
+                    }
+                    return messages;
+                });
+    }
+
+    private Mono<Void> cacheMessages(
+            String key, List<Message> messages) {
+        String serialized = serialize(messages);
+        return redisTemplate.opsForValue()
+                .set(key, serialized, SESSION_TTL)
+                .doOnSuccess(ok ->
+                        log.debug(
+                                "Cached {} msgs: {}",
+                                messages.size(), key))
+                .then();
+    }
+
+    private String serialize(List<Message> messages) {
+        StringBuilder sb = new StringBuilder();
+        for (Message msg : messages) {
+            if (msg.role() == null) continue;
+            if (msg.content() == null) continue;
+            sb.append(msg.role().name())
+                    .append(SEPARATOR)
+                    .append(msg.id().toString())
+                    .append(SEPARATOR)
+                    .append(msg.content()
+                            .replace("\n", "\\n"))
+                    .append(LINE_SEP);
+        }
+        return sb.toString();
+    }
+
+    private List<Message> deserialize(
+            String data, UUID sessionId) {
+        List<Message> messages = new ArrayList<>();
+        if (data == null || data.isBlank()) {
+            return messages;
+        }
+        String[] lines = data.split(LINE_SEP);
+        for (String line : lines) {
+            if (line.isBlank()) continue;
+            String[] parts = line.split(
+                    "\\" + SEPARATOR, 3);
+            if (parts.length < 3) continue;
+            try {
+                MessageRole role = MessageRole
+                        .valueOf(parts[0].trim());
+                UUID id = UUID.fromString(
+                        parts[1].trim());
+                String content = parts[2]
+                        .replace("\\n", "\n");
+                messages.add(new Message(
+                        id, sessionId, role, content,
+                        null, null, null, null, null,
+                        null, null, false, null,
+                        Instant.now()));
+            } catch (Exception e) {
+                log.warn("Skip line: {}", line);
+            }
+        }
+        return messages;
+    }
+}

--- a/server/src/main/java/ai/jarvis/memory/session/SessionCacheService.java
+++ b/server/src/main/java/ai/jarvis/memory/session/SessionCacheService.java
@@ -14,7 +14,6 @@ import reactor.core.publisher.Mono;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -22,13 +21,20 @@ import java.util.UUID;
  * Caches session message history in Redis.
  *
  * ENCODING: JSON Lines (one JSON object per line).
- * Each line: {"r":"ROLE","i":"uuid","c":"content"}
+ * Each line: {"r":"ROLE","i":"uuid","c":"content",
+ *             "e":false,"t":1234567890}
  *
- * WHY JSON Lines instead of custom escaping:
+ * WHY JSON Lines:
  * - Jackson handles all special chars correctly
  * - No data corruption for code, JSON, Windows paths
  * - Safe round-trip for any message content
- * - Still simple to parse (one object per line)
+ *
+ * WHY we store error flag and createdAt:
+ * - PromptAssembler checks msg.error() to exclude
+ *   error messages from prompts
+ * - Hardcoding false causes inconsistency between
+ *   cache HIT and DB fallback behavior
+ * - createdAt needed for correct message ordering
  */
 @Slf4j
 @Service
@@ -59,7 +65,7 @@ public class SessionCacheService {
 
     /**
      * Get session history.
-     * Cache HIT → Redis (~1ms)
+     * Cache HIT  → Redis (~1ms)
      * Cache MISS → PostgreSQL last 20 rows + cache
      */
     public Mono<List<Message>> getSessionHistory(
@@ -129,13 +135,12 @@ public class SessionCacheService {
 
     /**
      * Load last MAX_MESSAGES from DB at query level.
-     * No in-memory slicing needed.
+     * SQL LIMIT prevents loading entire session history.
      */
     private Mono<List<Message>> loadFromDb(
             UUID sessionId) {
         log.debug("Cache MISS [{}] — DB query",
                 sessionId);
-        // LIMIT pushed to DB query
         return messageRepository
                 .findLastNBySessionId(
                         sessionId, MAX_MESSAGES)
@@ -164,7 +169,7 @@ public class SessionCacheService {
     /**
      * Serialize as JSON Lines.
      * Each line = one MessageDto JSON object.
-     * Jackson handles all special chars correctly.
+     * Includes: role, id, content, error, createdAt.
      */
     private String serialize(
             List<Message> messages) throws Exception {
@@ -172,12 +177,18 @@ public class SessionCacheService {
         for (Message msg : messages) {
             if (msg.role() == null) continue;
             if (msg.content() == null) continue;
+
             MessageDto dto = new MessageDto(
                     msg.role().name(),
                     msg.id().toString(),
-                    msg.content()
+                    msg.content(),
+                    msg.error(),             // ← preserved
+                    msg.createdAt() != null  // ← preserved
+                            ? msg.createdAt().toEpochMilli()
+                            : Instant.now().toEpochMilli()
             );
-            sb.append(objectMapper.writeValueAsString(dto))
+            sb.append(
+                            objectMapper.writeValueAsString(dto))
                     .append("\n");
         }
         return sb.toString();
@@ -185,7 +196,13 @@ public class SessionCacheService {
 
     /**
      * Deserialize JSON Lines back to Message list.
-     * Fix: logs session ID only, NOT message content.
+     *
+     * FIXED: restores error flag and createdAt.
+     * PromptAssembler uses msg.error() to exclude
+     * error messages — must be preserved correctly.
+     *
+     * PRIVACY: logs session ID + line number only.
+     * Never logs message content.
      */
     private List<Message> deserialize(
             String data, UUID sessionId) {
@@ -203,19 +220,36 @@ public class SessionCacheService {
                 MessageDto dto = objectMapper
                         .readValue(line,
                                 MessageDto.class);
+
                 MessageRole role = MessageRole
                         .valueOf(dto.r());
                 UUID id = UUID.fromString(dto.i());
 
+                // Restore createdAt from stored epoch ms
+                Instant createdAt = dto.t() != null
+                        ? Instant.ofEpochMilli(dto.t())
+                        : Instant.now();
+
                 messages.add(new Message(
-                        id, sessionId, role, dto.c(),
-                        null, null, null, null, null,
-                        null, null, false, null,
-                        Instant.now()));
+                        id,
+                        sessionId,
+                        role,
+                        dto.c(),
+                        null,          // providerId
+                        null,          // modelName
+                        null,          // promptTokens
+                        null,          // completionTokens
+                        null,          // totalTokens
+                        null,          // durationMs
+                        null,          // finishReason
+                        dto.e(),       // ← error (fixed!)
+                        null,          // errorMessage
+                        createdAt      // ← real timestamp (fixed!)
+                ));
 
             } catch (Exception e) {
-                // Fix: log session ID + line number only
-                // NOT the line content (may contain user text)
+                // Log session ID + line number only.
+                // Never log message content (privacy).
                 log.warn(
                         "Parse failed session={} line={}: {}",
                         sessionId, lineNum,
@@ -230,10 +264,17 @@ public class SessionCacheService {
     /**
      * Minimal DTO for Redis storage.
      * Short field names to reduce Redis memory usage.
-     * r = role, i = id, c = content
+     *
+     * r = role
+     * i = id
+     * c = content
+     * e = error flag    ← NEW (fixes PromptAssembler)
+     * t = createdAt ms  ← NEW (fixes ordering)
      */
     private record MessageDto(
             @JsonProperty("r") String r,
             @JsonProperty("i") String i,
-            @JsonProperty("c") String c) {}
+            @JsonProperty("c") String c,
+            @JsonProperty("e") boolean e,   // ← NEW
+            @JsonProperty("t") Long t) {}   // ← NEW
 }

--- a/server/src/main/java/ai/jarvis/memory/session/SessionMemoryService.java
+++ b/server/src/main/java/ai/jarvis/memory/session/SessionMemoryService.java
@@ -1,0 +1,37 @@
+package ai.jarvis.memory.session;
+
+import ai.jarvis.chat.message.Message;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SessionMemoryService {
+
+    private final SessionCacheService sessionCacheService;
+
+    /**
+     * Load history: Redis first, PostgreSQL fallback.
+     */
+    public Mono<List<Message>> loadHistory(
+            UUID sessionId) {
+        return sessionCacheService
+                .getSessionHistory(sessionId);
+    }
+
+    /**
+     * Refresh cache after message saved.
+     * Reloads from DB and re-caches.
+     * Does NOT delete — persists for 1 hour TTL.
+     */
+    public Mono<Void> onMessageSaved(UUID sessionId) {
+        return sessionCacheService
+                .refreshCache(sessionId);
+    }
+}

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -40,6 +40,12 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       timeout: 2000ms
+      # Connection pool for reactive Redis
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 2
 
   # ── Spring AI ─────────────────────────────────────
   ai:
@@ -181,11 +187,12 @@ springdoc:
 # ═══════════════════════════════════════════════════
 logging:
   level:
-    ai.jarvis: INFO
+    ai.jarvis: WARN
     org.springframework: WARN
     io.r2dbc: WARN
     org.flywaydb: WARN
     reactor.netty: WARN
+    org.springframework.r2dbc: WARN
   file:
     name: ${user.home}/.jarvis/logs/jarvis.log
   logback:


### PR DESCRIPTION
Cosmetic fix: parameter names were misleading.
id should be first param (maps to id column).
userId should be second param (maps to user_id column). Functionally unchanged — Spring Data uses position not names.

## What Does This PR Do?

Added Redis as a fast cache layer for active sessions.
Currently every chat interaction loads history
from PostgreSQL (~50ms per query).
Redis reduces this to ~1ms.

Technical Approach
Add to pom.xml:
spring-boot-starter-data-redis-reactive

Add to docker-compose.yml:
redis:
image: redis:7-alpine
ports: ["6379:6379"]

Create SessionCacheService.java:

Cache: session + last 20 messages
Key: "session:{sessionId}"
TTL: 1 hour (clear if inactive)
Updated SessionMemoryService.java:

Check Redis first
Fall back to PostgreSQL if cache miss
Update cache after each message
 Improvement
Response initiation time:
Before Redis: ~100-150ms (DB query)
After Redis: ~5-10ms (cache hit)

---

## Related Issue

Closes #9 

---

## Type of Change

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [ ] 🧪 Tests
* [ ] 🔧 Maintenance / chore

---

## Testing

* [x] `./mvnw test` passes
* [x] Tested with Ollama running locally
* [ ] Tested on OS: _______________
* [ ] New tests added for this change

---

## Checklist

* [x] Code follows the project coding standards
* [x] I have reviewed my own changes
* [ ] Documentation updated (if needed)
* [ ] No secrets or API keys in the code
* [ ] Conventional commit messages used
* [x] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)

[Add screenshots or terminal output here]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Redis-backed session memory/cache for faster, more reliable chat history loading; history retrieval now preserves message order.
  * Chat flow now loads recent history from the cache and persists assistant responses with token and duration metadata.

* **Bug Fixes**
  * Assistant message saves consistently update session message counts and trigger cache refreshes.

* **Config**
  * Tuned Redis connection-pool and logging levels for production stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->