### PR TITLE
feat: add CLI examples command

### DIFF
--- a/server/src/main/java/ai/jarvis/cli/SystemCommands.java
+++ b/server/src/main/java/ai/jarvis/cli/SystemCommands.java
@@ -171,6 +171,27 @@ public class SystemCommands {
     }
 
     @Command(
+            name = "examples",
+            description = "Show common Jarvis CLI usage examples"
+    )
+    public String examples() {
+        return "\n"
+                + "QUICK START:\n"
+                + "  login               Sign in to Jarvis\n"
+                + "  chat                Start chatting with AI\n"
+                + "  ask -m \"question\"   Quick single question\n\n"
+                + "SESSION MANAGEMENT:\n"
+                + "  session             List all conversations\n"
+                + "  switch-session -n 2 Switch to session #2\n"
+                + "  new-session         Start fresh session\n\n"
+                + "SYSTEM:\n"
+                + "  status              Check all services\n"
+                + "  doctor              Full health diagnostics\n"
+                + "  jarvis-version      Version information\n"
+                + "  about               About Jarvis\n";
+    }
+
+    @Command(
             name = "about",
             description = "Show Jarvis platform information"
     )

--- a/server/src/test/java/ai/jarvis/cli/SystemCommandsTest.java
+++ b/server/src/test/java/ai/jarvis/cli/SystemCommandsTest.java
@@ -1,0 +1,36 @@
+package ai.jarvis.cli;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SystemCommands Tests")
+class SystemCommandsTest {
+
+    @Test
+    @DisplayName("examples command should show quick start, session, and system commands")
+    void examplesCommandShouldShowCommandGroups() {
+        SystemCommands commands = new SystemCommands(
+                new CliStateManager(),
+                new CliHttpClient()
+        );
+
+        String output = commands.examples();
+
+        assertThat(output)
+                .contains("QUICK START:")
+                .contains("login")
+                .contains("chat")
+                .contains("ask -m \"question\"")
+                .contains("SESSION MANAGEMENT:")
+                .contains("session")
+                .contains("switch-session -n 2")
+                .contains("new-session")
+                .contains("SYSTEM:")
+                .contains("status")
+                .contains("doctor")
+                .contains("jarvis-version")
+                .contains("about");
+    }
+}


### PR DESCRIPTION
## Summary
- add a Spring Shell `examples` command for quick-start, session-management, and system command examples
- cover the new command output with a focused `SystemCommandsTest`

Closes #4

## Verification
- RED: `./mvnw -Dtest=SystemCommandsTest test` failed before implementation because `SystemCommands.examples()` did not exist
- GREEN: `./mvnw -q -Dtest=SystemCommandsTest test`
- `./mvnw -q -DskipTests compile`
- `git diff --cached --check`

## Notes
- Full `./mvnw -q test` was attempted and ran 29 tests, but the existing `JarvisApplicationTests.contextLoads` requires local PostgreSQL on `localhost:5433`; it failed with connection refused because the database is not running in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an `examples` command providing quick-start usage help text covering login, chat, session management, and core system commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->