### PR TITLE
feat: show chat stream stats

### DIFF
--- a/server/src/main/java/ai/jarvis/cli/ChatCommands.java
+++ b/server/src/main/java/ai/jarvis/cli/ChatCommands.java
@@ -10,6 +10,7 @@ import org.springframework.shell.core.command.annotation.Command;
 import org.springframework.shell.core.command.annotation.Option;
 import org.springframework.stereotype.Component;
 
+import java.util.Locale;
 import java.util.UUID;
 
 @Slf4j
@@ -167,8 +168,13 @@ public class ChatCommands {
                     System.out.print(token);
                     System.out.flush();
                 },
-                () -> {
+                stats -> {
                     System.out.println();
+                    String statsLine =
+                            formatStreamStats(stats);
+                    if (!statsLine.isEmpty()) {
+                        System.out.println(statsLine);
+                    }
                     System.out.println();
                     System.out.flush();
                 },
@@ -178,6 +184,19 @@ public class ChatCommands {
                                     + formatError(error));
                     System.out.flush();
                 }
+        );
+    }
+
+    static String formatStreamStats(
+            CliHttpClient.StreamStats stats) {
+        if (stats == null || stats.tokens() <= 0) {
+            return "";
+        }
+        return String.format(
+                Locale.ROOT,
+                "        -- %d tokens · %.1fs --",
+                stats.tokens(),
+                stats.durationMs() / 1000.0
         );
     }
 

--- a/server/src/main/java/ai/jarvis/cli/CliHttpClient.java
+++ b/server/src/main/java/ai/jarvis/cli/CliHttpClient.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @Component
@@ -118,15 +120,22 @@ public class CliHttpClient {
 
     // ── Streaming (for chat) ──────────────────────
 
+    public record StreamStats(
+            int tokens,
+            long durationMs
+    ) {}
+
     public void streamChat(
             String token,
             Object body,
             java.util.function.Consumer<String> onSession,
             java.util.function.Consumer<String> onToken,
-            Runnable onDone,
+            java.util.function.Consumer<StreamStats> onDone,
             java.util.function.Consumer<String> onError) {
 
         try {
+            long startedAtNanos = System.nanoTime();
+            AtomicInteger tokenCount = new AtomicInteger();
             var webClient = org.springframework.web
                     .reactive.function.client
                     .WebClient.builder()
@@ -161,10 +170,16 @@ public class CliHttpClient {
                             String tokenText =
                                     parseJsonToken(event.data());
                             if (tokenText != null) {
+                                tokenCount.incrementAndGet();
                                 onToken.accept(tokenText);
                             }
                         } else if ("done".equals(eventType)) {
-                            onDone.run();
+                            long durationMs = TimeUnit.NANOSECONDS
+                                    .toMillis(System.nanoTime()
+                                            - startedAtNanos);
+                            onDone.accept(new StreamStats(
+                                    tokenCount.get(),
+                                    durationMs));
                         }
                     })
                     .doOnError(err ->

--- a/server/src/test/java/ai/jarvis/cli/ChatCommandsTest.java
+++ b/server/src/test/java/ai/jarvis/cli/ChatCommandsTest.java
@@ -1,0 +1,31 @@
+package ai.jarvis.cli;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ChatCommands Tests")
+class ChatCommandsTest {
+
+    @Test
+    @DisplayName("Should format stream stats after a tokenized response")
+    void shouldFormatStreamStats() {
+        String line = ChatCommands.formatStreamStats(
+                new CliHttpClient.StreamStats(16, 7500)
+        );
+
+        assertThat(line)
+                .isEqualTo("        -- 16 tokens · 7.5s --");
+    }
+
+    @Test
+    @DisplayName("Should hide stream stats when no tokens were counted")
+    void shouldHideEmptyStreamStats() {
+        String line = ChatCommands.formatStreamStats(
+                new CliHttpClient.StreamStats(0, 7500)
+        );
+
+        assertThat(line).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- add `StreamStats` for CLI chat streaming completion callbacks
- count streamed token events and measure elapsed response time in `CliHttpClient.streamChat`
- print a compact `tokens · seconds` stats line after AI responses only when token count is positive

Closes #3

## Tests
- RED: `./mvnw -Dtest=ChatCommandsTest test` failed before implementation because `CliHttpClient.StreamStats` did not exist
- GREEN: `./mvnw -q -Dtest=ChatCommandsTest test`
- `./mvnw -q -DskipTests compile`
- `git diff --check`
- Full `./mvnw -q test` attempted; it still fails in existing `JarvisApplicationTests.contextLoads` because local PostgreSQL at `localhost:5433` is not running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Streaming chat requests now display token count and duration statistics upon completion. These metrics appear in a formatted summary after each stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->