### PR TITLE
feat: add MemoryService with CRUD operations

### DIFF
--- a/server/src/main/java/ai/jarvis/memory/MemoryService.java
+++ b/server/src/main/java/ai/jarvis/memory/MemoryService.java
@@ -1,0 +1,387 @@
+package ai.jarvis.memory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+/**
+ * Core memory management service.
+ *
+ * WHAT THIS SERVICE DOES:
+ * Coordinates between the outside world (controllers, CLI)
+ * and the database (MemoryRepository).
+ *
+ * BUSINESS RULES ENFORCED HERE:
+ * 1. No empty content saved
+ * 2. No duplicate memories for same user
+ * 3. Only owner can delete their memory
+ * 4. Access count tracked when memories retrieved
+ * 5. Memories formatted correctly for prompt injection
+ *
+ * WHY SEPARATE FROM REPOSITORY:
+ * Repository only knows SQL operations.
+ * Service knows the RULES of the application.
+ * Keeping them separate makes both easier to test.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemoryService {
+
+    private final MemoryRepository memoryRepository;
+    private final R2dbcEntityTemplate r2dbcEntityTemplate;
+
+    // Maximum memories to inject into one prompt
+    // Too many = fills context window
+    // Too few = misses important context
+    private static final int DEFAULT_PROMPT_LIMIT = 5;
+
+    // ── Save Operations ───────────────────────────
+
+    /**
+     * Save a memory extracted from a conversation.
+     *
+     * WHY: AiOrchestrator calls this after each chat
+     * to store what Jarvis learned about the user.
+     *
+     * BUSINESS RULES:
+     * 1. Content must not be blank
+     * 2. Skip if identical memory already exists
+     *    (prevents duplicate extraction)
+     *
+     * @param userId        who this memory belongs to
+     * @param type          FACT/GOAL/PREFERENCE/CONTEXT/EVENT
+     * @param content       the actual memory text
+     * @param sourceSession which session this came from
+     */
+    public Mono<Memory> save(
+            UUID userId,
+            MemoryType type,
+            String content,
+            UUID sourceSession) {
+
+        // Rule 1: Reject empty content
+        // Empty strings waste DB space and
+        // confuse the AI when injected into prompts
+        if (content == null || content.isBlank()) {
+            log.debug(
+                    "Skipping empty memory for user={}",
+                    userId);
+            return Mono.empty();
+        }
+
+        String trimmedContent = content.trim();
+
+        // Rule 2: Check for duplicate before saving
+        // If user said "I use Java" twice in two sessions,
+        // we should not store "User uses Java" twice.
+        // .flatMap() here because existsByUserId...
+        // is an async database call (returns Mono<Boolean>)
+        return memoryRepository
+                .existsByUserIdAndContentIgnoreCase(
+                        userId, trimmedContent)
+                .flatMap(exists -> {
+                    if (exists) {
+                        log.debug(
+                                "Skipping duplicate memory: "
+                                        + "user={} content preview={}",
+                                userId,
+                                trimmedContent.substring(0,
+                                        Math.min(30,
+                                                trimmedContent.length()))
+                        );
+                        return Mono.empty();
+                    }
+
+                    // No duplicate — create and save
+                    Memory memory = Memory.create(
+                            userId,
+                            type,
+                            trimmedContent,
+                            sourceSession
+                    );
+
+                    // Use insert() not save()!
+                    // save() with non-null UUID = UPDATE
+                    // insert() always = INSERT
+                    // We learned this lesson the hard way
+                    // during authentication implementation
+                    return r2dbcEntityTemplate
+                            .insert(memory)
+                            .doOnSuccess(saved ->
+                                    log.info(
+                                            "Memory saved: "
+                                                    + "type={} user={}",
+                                            saved.type(),
+                                            saved.userId()
+                                    )
+                            );
+                });
+    }
+
+    /**
+     * Save a memory added manually by the user.
+     *
+     * WHY SEPARATE FROM save():
+     * Manual memories have no sourceSession.
+     * They come from CLI "memory add" command.
+     * The user explicitly chose to remember this.
+     * We still check for duplicates.
+     *
+     * @param userId  who this memory belongs to
+     * @param type    FACT/GOAL/PREFERENCE/CONTEXT/EVENT
+     * @param content the actual memory text
+     */
+    public Mono<Memory> saveManual(
+            UUID userId,
+            MemoryType type,
+            String content) {
+
+        // Delegate to save() with null sourceSession
+        // save() handles all validation rules
+        return save(userId, type, content, null);
+    }
+
+    // ── Retrieve Operations ───────────────────────
+
+    /**
+     * Get ALL memories for a user.
+     *
+     * WHY: Used by CLI "memory list" command
+     * and REST API GET /api/v1/memories.
+     *
+     * Returns Flux not List because:
+     * → Flux = reactive stream (non-blocking)
+     * → Items delivered ONE BY ONE as DB reads them
+     * → Works perfectly with WebFlux SSE streaming
+     * → More memory efficient for large lists
+     *
+     * @param userId who to fetch memories for
+     */
+    public Flux<Memory> getAll(UUID userId) {
+        return memoryRepository
+                .findByUserIdOrderByImportanceDesc(userId);
+    }
+
+    /**
+     * Get top N memories for prompt injection.
+     *
+     * WHY: Called by PromptAssembler before every
+     * AI request to inject relevant context.
+     *
+     * ALSO TRACKS ACCESS:
+     * Each retrieved memory gets access_count++
+     * This makes the system smarter over time:
+     * frequently accessed memories rank higher.
+     *
+     * WHY ASYNC ACCESS TRACKING:
+     * We fire-and-forget the incrementAccessCount.
+     * We do NOT wait for it to complete.
+     * Why? The user is waiting for AI response.
+     * We must not slow down the chat for bookkeeping.
+     *
+     * @param userId how to fetch memories for
+     * @param limit  max memories to return
+     */
+    public Flux<Memory> getTop(UUID userId, int limit) {
+        return memoryRepository
+                .findTopMemoriesByUserId(userId, limit)
+                .doOnNext(memory ->
+                        // Track access ASYNC
+                        // .subscribe() = fire and forget
+                        // Does NOT block the stream
+                        memoryRepository
+                                .incrementAccessCount(memory.id())
+                                .subscribe(
+                                        null,  // onNext: ignore
+                                        error -> log.warn(
+                                                "Access count update "
+                                                        + "failed for memory={}: {}",
+                                                memory.id(),
+                                                error.getMessage())
+                                )
+                );
+    }
+
+    /**
+     * Get top memories using default limit (5).
+     * Convenience method for prompt injection.
+     *
+     * @param userId who to fetch memories for
+     */
+    public Flux<Memory> getTopForPrompt(UUID userId) {
+        return getTop(userId, DEFAULT_PROMPT_LIMIT);
+    }
+
+    /**
+     * Get memories filtered by type.
+     *
+     * WHY: When user says "show my goals"
+     * we only want GOAL type memories.
+     *
+     * @param userId who to fetch memories for
+     * @param type   which type to filter by
+     */
+    public Flux<Memory> getByType(
+            UUID userId, MemoryType type) {
+        return memoryRepository
+                .findByUserIdAndTypeOrderByImportanceDesc(
+                        userId, type);
+    }
+
+    /**
+     * Count total memories for a user.
+     *
+     * WHY: CLI "memory list" shows count in header.
+     * "Your memories (47 total)"
+     *
+     * @param userId who to count memories for
+     */
+    public Mono<Long> count(UUID userId) {
+        return memoryRepository.countByUserId(userId);
+    }
+
+    // ── Delete Operations ─────────────────────────
+
+    /**
+     * Delete a specific memory.
+     *
+     * SECURITY RULE:
+     * Verify the memory belongs to this user
+     * BEFORE deleting it.
+     *
+     * WHY THIS MATTERS:
+     * Without this check:
+     * User A could delete User B's memories
+     * by guessing UUIDs.
+     *
+     * With findByIdAndUserId():
+     * → If memory exists AND belongs to userId → delete
+     * → If memory not found OR wrong user → 404 error
+     *
+     * @param memoryId which memory to delete
+     * @param userId   must be the owner
+     */
+    public Mono<Void> delete(
+            UUID memoryId, UUID userId) {
+
+        return memoryRepository
+                .findByIdAndUserId(memoryId, userId)
+                .switchIfEmpty(Mono.error(
+                        // 404 if not found OR wrong owner
+                        // We say "not found" not "forbidden"
+                        // This prevents attackers from knowing
+                        // if a memory ID exists at all
+                        new ResponseStatusException(
+                                HttpStatus.NOT_FOUND,
+                                "Memory not found"
+                        )
+                ))
+                .flatMap(memory ->
+                        memoryRepository.delete(memory)
+                )
+                .doOnSuccess(v ->
+                        log.info(
+                                "Memory deleted: id={} user={}",
+                                memoryId, userId)
+                );
+    }
+
+    /**
+     * Delete ALL memories for a user.
+     *
+     * WHY: CLI "memory clear" command.
+     * User explicitly wants to wipe their memory.
+     *
+     * NOTE: No ownership check needed here because
+     * we use userId directly — user can only delete
+     * their OWN memories by definition.
+     *
+     * @param userId who to clear memories for
+     */
+    public Mono<Void> deleteAll(UUID userId) {
+        return memoryRepository
+                .deleteByUserId(userId)
+                .doOnSuccess(v ->
+                        log.info(
+                                "All memories cleared: user={}",
+                                userId)
+                );
+    }
+
+    // ── Prompt Formatting ─────────────────────────
+
+    /**
+     * Format top memories as a string for AI prompt.
+     *
+     * WHY: PromptAssembler calls this to get a
+     * formatted string to inject into the AI prompt.
+     *
+     * OUTPUT EXAMPLE:
+     * "=== WHAT I KNOW ABOUT YOU ===
+     *  - [FACT] Your name is Dravin
+     *  - [GOAL] Building Jarvis AI Platform
+     *  - [PREFERENCE] Prefers detailed explanations
+     *  ==========================="
+     *
+     * The AI reads this and uses it to personalize
+     * responses WITHOUT us explicitly saying anything.
+     *
+     * WHY Mono<String> not String:
+     * We need to call the database (async).
+     * Database calls return Mono/Flux.
+     * We chain: DB call → collect list → format string
+     * All non-blocking via Reactor operators.
+     *
+     * @param userId     whose memories to format
+     * @param maxMemories how many to include
+     */
+    public Mono<String> formatForPrompt(
+            UUID userId, int maxMemories) {
+
+        return getTop(userId, maxMemories)
+                .collectList()
+                // .map() here because formatting a List
+                // is synchronous (no more DB calls)
+                .map(memories -> {
+                    // If no memories: return empty string
+                    // PromptAssembler skips empty strings
+                    if (memories.isEmpty()) {
+                        return "";
+                    }
+
+                    // Build the formatted string
+                    StringBuilder sb = new StringBuilder();
+                    sb.append(
+                            "=== WHAT I KNOW ABOUT YOU ===\n");
+
+                    for (Memory memory : memories) {
+                        sb.append("- [")
+                                .append(memory.type().name())
+                                .append("] ")
+                                .append(memory.content())
+                                .append("\n");
+                    }
+
+                    sb.append("============================");
+                    return sb.toString();
+                });
+    }
+
+    /**
+     * Format using default limit.
+     * Convenience method for PromptAssembler.
+     *
+     * @param userId whose memories to format
+     */
+    public Mono<String> formatForPrompt(UUID userId) {
+        return formatForPrompt(userId, DEFAULT_PROMPT_LIMIT);
+    }
+}

--- a/server/src/main/java/ai/jarvis/memory/MemoryService.java
+++ b/server/src/main/java/ai/jarvis/memory/MemoryService.java
@@ -84,19 +84,17 @@ public class MemoryService {
         // we should not store "User uses Java" twice.
         // .flatMap() here because existsByUserId...
         // is an async database call (returns Mono<Boolean>)
+        // Application-level check (fast path optimization)
+        // DB unique constraint is the real safety net
         return memoryRepository
                 .existsByUserIdAndContentIgnoreCase(
                         userId, trimmedContent)
                 .flatMap(exists -> {
                     if (exists) {
                         log.debug(
-                                "Skipping duplicate memory: "
-                                        + "user={} content preview={}",
-                                userId,
-                                trimmedContent.substring(0,
-                                        Math.min(30,
-                                                trimmedContent.length()))
-                        );
+                                "Skipping duplicate memory "
+                                        + "for user={}",
+                                userId);
                         return Mono.empty();
                     }
 
@@ -120,9 +118,28 @@ public class MemoryService {
                                             "Memory saved: "
                                                     + "type={} user={}",
                                             saved.type(),
-                                            saved.userId()
-                                    )
-                            );
+                                            saved.userId())
+                            )
+                            // Handle DB unique constraint violation
+                            // (concurrent insert race condition)
+                            .onErrorResume(error -> {
+                                String msg = error.getMessage();
+                                if (msg != null && (
+                                        msg.contains("unique")
+                                                || msg.contains("duplicate")
+                                                || msg.contains("23505"))) {
+                                    // PostgreSQL error code 23505
+                                    // = unique_violation
+                                    log.debug(
+                                            "Concurrent duplicate "
+                                                    + "prevented by DB "
+                                                    + "constraint: user={}",
+                                            userId);
+                                    return Mono.empty();
+                                }
+                                // Other errors: re-throw
+                                return Mono.error(error);
+                            });
                 });
     }
 
@@ -191,6 +208,11 @@ public class MemoryService {
      * @param limit  max memories to return
      */
     public Flux<Memory> getTop(UUID userId, int limit) {
+        // Guard: negative or zero limit returns nothing
+        if (limit <= 0) {
+            return Flux.empty();
+        }
+
         return memoryRepository
                 .findTopMemoriesByUserId(userId, limit)
                 .doOnNext(memory ->
@@ -200,7 +222,7 @@ public class MemoryService {
                         memoryRepository
                                 .incrementAccessCount(memory.id())
                                 .subscribe(
-                                        null,  // onNext: ignore
+                                        null,
                                         error -> log.warn(
                                                 "Access count update "
                                                         + "failed for memory={}: {}",
@@ -345,6 +367,10 @@ public class MemoryService {
      */
     public Mono<String> formatForPrompt(
             UUID userId, int maxMemories) {
+        // Guard: invalid limit returns empty string
+        if (maxMemories <= 0) {
+            return Mono.just("");
+        }
 
         return getTop(userId, maxMemories)
                 .collectList()
@@ -359,9 +385,7 @@ public class MemoryService {
 
                     // Build the formatted string
                     StringBuilder sb = new StringBuilder();
-                    sb.append(
-                            "=== WHAT I KNOW ABOUT YOU ===\n");
-
+                    sb.append("=== WHAT I KNOW ABOUT YOU ===\n");
                     for (Memory memory : memories) {
                         sb.append("- [")
                                 .append(memory.type().name())
@@ -369,7 +393,6 @@ public class MemoryService {
                                 .append(memory.content())
                                 .append("\n");
                     }
-
                     sb.append("============================");
                     return sb.toString();
                 });

--- a/server/src/main/resources/db/migration/V12__add_memories_unique_constraint.sql
+++ b/server/src/main/resources/db/migration/V12__add_memories_unique_constraint.sql
@@ -1,0 +1,30 @@
+-- ═══════════════════════════════════════════════════
+-- V12: Add unique constraint on memories (user_id, content)
+-- Phase 2: Memory System
+--
+-- WHY THIS IS NEEDED:
+-- MemoryService.save() does check-then-insert:
+--   1. Check if duplicate exists (SELECT)
+--   2. Insert if not (INSERT)
+-- Under concurrent requests, two threads can both
+-- pass the check and both insert → duplicates!
+--
+-- DB-level constraint makes duplicates impossible
+-- regardless of concurrency. The application-level
+-- check becomes a fast-path optimization only.
+--
+-- WHY LOWER(TRIM(content)):
+-- "User is building Jarvis" and
+-- "user is building jarvis " are the same memory.
+-- Normalize before comparing.
+-- ═══════════════════════════════════════════════════
+
+-- Functional unique index on normalized content
+-- Prevents duplicates even under concurrent inserts
+CREATE UNIQUE INDEX idx_memories_user_content_unique
+    ON memories (user_id, LOWER(TRIM(content)));
+
+COMMENT ON INDEX idx_memories_user_content_unique IS
+    'Prevents duplicate memories per user.
+     Normalized (lowercased + trimmed) for comparison.
+     Application-level check is optimization only.';

--- a/server/src/test/java/ai/jarvis/memory/MemoryServiceTest.java
+++ b/server/src/test/java/ai/jarvis/memory/MemoryServiceTest.java
@@ -1,0 +1,154 @@
+package ai.jarvis.memory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;  // ← ADD
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemoryService Tests")
+class MemoryServiceTest {
+
+    @Mock
+    private MemoryRepository memoryRepository;
+
+    @Mock
+    private R2dbcEntityTemplate r2dbcEntityTemplate;
+
+    @InjectMocks
+    private MemoryService memoryService;
+
+    private UUID userId;
+    private UUID sessionId;
+    private Memory testMemory;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        sessionId = UUID.randomUUID();
+        testMemory = new Memory(
+                UUID.randomUUID(),
+                userId,
+                MemoryType.FACT,
+                "User is building Jarvis",
+                sessionId,
+                0.50, 0, null,
+                Instant.now(), Instant.now()
+        );
+    }
+
+    @Test
+    @DisplayName("save() returns empty for blank content")
+    void saveShouldReturnEmptyForBlankContent() {
+        StepVerifier
+                .create(memoryService.save(
+                        userId, MemoryType.FACT,
+                        "   ", sessionId))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("save() skips duplicate memories")
+    void saveShouldSkipDuplicates() {
+        when(memoryRepository
+                .existsByUserIdAndContentIgnoreCase(
+                        userId, "User is building Jarvis"))
+                .thenReturn(Mono.just(true));
+
+        StepVerifier
+                .create(memoryService.save(
+                        userId, MemoryType.FACT,
+                        "User is building Jarvis",
+                        sessionId))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("save() saves unique memories")
+    void saveShouldSaveUniqueMemory() {
+        when(memoryRepository
+                .existsByUserIdAndContentIgnoreCase(
+                        any(), any()))
+                .thenReturn(Mono.just(false));
+
+        when(r2dbcEntityTemplate
+                .insert(any(Memory.class)))
+                .thenReturn(Mono.just(testMemory));
+
+        StepVerifier
+                .create(memoryService.save(
+                        userId, MemoryType.FACT,
+                        "User is building Jarvis",
+                        sessionId))
+                .expectNextMatches(m ->
+                        m.type() == MemoryType.FACT
+                                && m.content().equals(
+                                "User is building Jarvis"))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("count() returns correct count")
+    void countShouldReturnCorrectCount() {
+        when(memoryRepository.countByUserId(userId))
+                .thenReturn(Mono.just(5L));
+
+        StepVerifier
+                .create(memoryService.count(userId))
+                .expectNext(5L)
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("formatForPrompt() empty when no memories")
+    void formatForPromptShouldReturnEmptyForNoMemories() {
+        // ← FIX: anyInt() for primitive int parameter
+        when(memoryRepository
+                .findTopMemoriesByUserId(
+                        eq(userId), anyInt()))
+                .thenReturn(Flux.empty());
+
+        StepVerifier
+                .create(memoryService.formatForPrompt(userId))
+                .expectNext("")
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("formatForPrompt() includes type and content")
+    void formatForPromptShouldIncludeMemories() {
+        // anyInt() for primitive int parameter
+        when(memoryRepository
+                .findTopMemoriesByUserId(
+                        eq(userId), anyInt()))
+                .thenReturn(Flux.just(testMemory));
+
+        when(memoryRepository
+                .incrementAccessCount(any()))
+                .thenReturn(Mono.just(1));
+
+        StepVerifier
+                .create(memoryService.formatForPrompt(userId))
+                .expectNextMatches(result ->
+                        result.contains("[FACT]")
+                                && result.contains(
+                                "User is building Jarvis")
+                                && result.contains("WHAT I KNOW"))
+                .verifyComplete();
+    }
+}

--- a/server/src/test/java/ai/jarvis/memory/MemoryServiceTest.java
+++ b/server/src/test/java/ai/jarvis/memory/MemoryServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -16,8 +17,10 @@ import java.time.Instant;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;  // ← ADD
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,6 +55,8 @@ class MemoryServiceTest {
         );
     }
 
+    // ── save() tests ──────────────────────────────
+
     @Test
     @DisplayName("save() returns empty for blank content")
     void saveShouldReturnEmptyForBlankContent() {
@@ -67,7 +72,8 @@ class MemoryServiceTest {
     void saveShouldSkipDuplicates() {
         when(memoryRepository
                 .existsByUserIdAndContentIgnoreCase(
-                        userId, "User is building Jarvis"))
+                        userId,
+                        "User is building Jarvis"))
                 .thenReturn(Mono.just(true));
 
         StepVerifier
@@ -102,6 +108,22 @@ class MemoryServiceTest {
                 .verifyComplete();
     }
 
+    // ── getTop() tests ────────────────────────────
+
+    @Test
+    @DisplayName("getTop() returns empty for limit <= 0")
+    void getTopShouldReturnEmptyForNonPositiveLimit() {
+        StepVerifier
+                .create(memoryService.getTop(userId, 0))
+                .verifyComplete();
+
+        StepVerifier
+                .create(memoryService.getTop(userId, -1))
+                .verifyComplete();
+    }
+
+    // ── count() tests ─────────────────────────────
+
     @Test
     @DisplayName("count() returns correct count")
     void countShouldReturnCorrectCount() {
@@ -114,17 +136,75 @@ class MemoryServiceTest {
                 .verifyComplete();
     }
 
+    // ── delete() tests ─────────────────────────────
+
+    @Test
+    @DisplayName("delete() returns 404 when not owned")
+    void deleteShouldReturn404WhenNotOwned() {
+        UUID memoryId = UUID.randomUUID();
+
+        when(memoryRepository
+                .findByIdAndUserId(memoryId, userId))
+                .thenReturn(Mono.empty());
+
+        StepVerifier
+                .create(memoryService
+                        .delete(memoryId, userId))
+                .expectErrorMatches(ex ->
+                        ex instanceof ResponseStatusException rse
+                                && rse.getStatusCode().value() == 404)
+                .verify();
+
+        // Verify delete was NEVER called
+        // (ownership check failed correctly)
+        verify(memoryRepository, never())
+                .delete(any(Memory.class));
+    }
+
+    @Test
+    @DisplayName("delete() succeeds when owned by user")
+    void deleteShouldSucceedWhenOwned() {
+        UUID memoryId = testMemory.id();
+
+        when(memoryRepository
+                .findByIdAndUserId(memoryId, userId))
+                .thenReturn(Mono.just(testMemory));
+
+        when(memoryRepository.delete(testMemory))
+                .thenReturn(Mono.empty());
+
+        StepVerifier
+                .create(memoryService
+                        .delete(memoryId, userId))
+                .verifyComplete();
+
+        // Verify delete WAS called with correct memory
+        verify(memoryRepository).delete(testMemory);
+    }
+
+    // ── formatForPrompt() tests ───────────────────
+
+    @Test
+    @DisplayName("formatForPrompt() empty for limit <= 0")
+    void formatForPromptShouldReturnEmptyForZeroLimit() {
+        StepVerifier
+                .create(memoryService
+                        .formatForPrompt(userId, 0))
+                .expectNext("")
+                .verifyComplete();
+    }
+
     @Test
     @DisplayName("formatForPrompt() empty when no memories")
     void formatForPromptShouldReturnEmptyForNoMemories() {
-        // ← FIX: anyInt() for primitive int parameter
         when(memoryRepository
                 .findTopMemoriesByUserId(
                         eq(userId), anyInt()))
                 .thenReturn(Flux.empty());
 
         StepVerifier
-                .create(memoryService.formatForPrompt(userId))
+                .create(memoryService
+                        .formatForPrompt(userId))
                 .expectNext("")
                 .verifyComplete();
     }
@@ -132,7 +212,6 @@ class MemoryServiceTest {
     @Test
     @DisplayName("formatForPrompt() includes type and content")
     void formatForPromptShouldIncludeMemories() {
-        // anyInt() for primitive int parameter
         when(memoryRepository
                 .findTopMemoriesByUserId(
                         eq(userId), anyInt()))
@@ -143,7 +222,8 @@ class MemoryServiceTest {
                 .thenReturn(Mono.just(1));
 
         StepVerifier
-                .create(memoryService.formatForPrompt(userId))
+                .create(memoryService
+                        .formatForPrompt(userId))
                 .expectNextMatches(result ->
                         result.contains("[FACT]")
                                 && result.contains(


### PR DESCRIPTION
## What Does This PR Do?

Phase 2: MemoryService — business logic layer

MemoryService.java:
- save(): validates content, checks duplicates, inserts
- saveManual(): for CLI manual memory addition
- getAll(): all memories ordered by importance
- getTop(): top N for prompt injection with access tracking
- getTopForPrompt(): convenience with default limit (5)
- getByType(): filtered by FACT/GOAL/PREFERENCE/CONTEXT/EVENT
- count(): total memory count for user
- delete(): ownership verified, 404 not 403 for security
- deleteAll(): wipe all memories for user
- formatForPrompt(): formatted string for AI prompt injection

Business rules enforced:
- Empty/blank content rejected
- Duplicate memories prevented (case-insensitive)
- Ownership verified before delete
- Access count tracked async (fire-and-forget)

MemoryServiceTest.java:
- 6 unit tests using Mockito + StepVerifier
- No database required for tests
- Tests: duplicate prevention, empty content, save success, count, prompt formatting



---

## Related Issue

Closes  #31 

---

## Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [ ] 🧪 Tests
* [ ] 🔧 Maintenance / chore

---

## Testing

* [ ] `./mvnw test` passes
* [ ] Tested with Ollama running locally
* [ ] Tested on OS: _______________
* [ ] New tests added for this change

---

## Checklist

* [ ] Code follows the project coding standards
* [ ] I have reviewed my own changes
* [ ] Documentation updated (if needed)
* [ ] No secrets or API keys in the code
* [ ] Conventional commit messages used
* [ ] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)

[Add screenshots or terminal output here]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save, retrieve, delete, and prioritize user memories with formatted prompt output.
  * Trim/normalize input and skip case-insensitive duplicates; formatted prompt lists memories as typed items.

* **Bug Fixes**
  * Reject blank content, handle concurrent insert races gracefully, enforce ownership on deletes (404 when not owned).
  * getTop returns empty for non-positive limits; access counts incremented asynchronously.

* **Chores**
  * Added database uniqueness enforcement to prevent normalized duplicate memories.

* **Tests**
  * Expanded test suite covering save, deduplication, retrieval limits, deletion ownership, counting, and prompt formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->