### PR TITLE
Cover AiOrchestrator with unit tests

### DIFF
--- a/server/src/test/java/ai/jarvis/ai/orchestrator/AiOrchestratorTest.java
+++ b/server/src/test/java/ai/jarvis/ai/orchestrator/AiOrchestratorTest.java
@@ -1,0 +1,294 @@
+package ai.jarvis.ai.orchestrator;
+
+import static ai.jarvis.ai.orchestrator.OrchestratorRequestFactory.generateOrchestrationRequest;
+import static ai.jarvis.chat.message.MessageFactory.generateAssistantMessage;
+import static ai.jarvis.chat.message.MessageFactory.generateUserMessage;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import ai.jarvis.ai.prompt.PromptAssembler;
+import ai.jarvis.ai.prompt.WorkingMemoryBuilder;
+import ai.jarvis.ai.provider.AiProvider;
+import ai.jarvis.ai.provider.GeminiProvider;
+import ai.jarvis.ai.provider.OllamaProvider;
+import ai.jarvis.ai.provider.ProviderRouter;
+import ai.jarvis.chat.message.Message;
+import ai.jarvis.chat.message.MessageRole;
+import ai.jarvis.chat.session.ChatSessionRepository;
+import ai.jarvis.memory.MemoryExtractionService;
+import ai.jarvis.memory.MemoryService;
+import ai.jarvis.memory.session.SessionMemoryService;
+import ai.jarvis.rag.RagSearchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class AiOrchestratorTest {
+
+    private static final String MEMORY_CONTEXT = "memory context";
+    private static final String RAG_CONTEXT = "rag context";
+    private static final String WORKING_MEMORY = "working memory";
+    private static final String MODEL_NAME = "abstract_model_name";
+    public static final String OLLAMA_MODEL_NAME = "ollama_model_name";
+    public static final String GEMINI_MODEL_NAME = "gemini_model_name";
+
+    @Mock
+    private ProviderRouter providerRouter;
+
+    @Mock
+    private ChatSessionRepository sessionRepository;
+
+    @Mock
+    private R2dbcEntityTemplate r2dbcEntityTemplate;
+
+    @Mock
+    private PromptAssembler promptAssembler;
+
+    @Mock
+    private WorkingMemoryBuilder workingMemoryBuilder;
+
+    @Mock
+    private SessionMemoryService sessionMemoryService;
+
+    @Mock
+    private MemoryService memoryService;
+
+    @Mock
+    private MemoryExtractionService memoryExtractionService;
+
+    @Mock
+    private RagSearchService ragSearchService;
+
+    @InjectMocks
+    private AiOrchestrator aiOrchestrator;
+
+    @Test
+    @DisplayName("Should save user message before calling AI")
+    void shouldSaveUserMessageBeforeCallingAI() {
+        // Given
+        OrchestratorRequest orchestratorRequest = generateOrchestrationRequest();
+
+        UUID sessionId = orchestratorRequest.sessionId();
+        UUID userId = orchestratorRequest.userId();
+        String username = orchestratorRequest.username();
+        String message = orchestratorRequest.message();
+        Message userMsg = generateUserMessage(sessionId, message);
+
+        Prompt prompt = mock(Prompt.class);
+        AiProvider aiProvider = mock(AiProvider.class);
+        when(aiProvider.streamChat(prompt)).thenReturn(Flux.just("Hello"," back"));
+        when(aiProvider.getModelName()).thenReturn(MODEL_NAME);
+
+        when(this.r2dbcEntityTemplate.insert(any(Message.class))).thenReturn(Mono.just(userMsg));
+        when(this.sessionMemoryService.loadHistory(sessionId)).thenReturn(Mono.just(List.of()));
+        when(this.memoryService.formatForPrompt(userId, message)).thenReturn(Mono.just(MEMORY_CONTEXT));
+        when(this.ragSearchService.formatForPrompt(userId, message)).thenReturn(Mono.just(RAG_CONTEXT));
+        when(this.providerRouter.route()).thenReturn(Mono.just(aiProvider));
+        when(this.workingMemoryBuilder.build(username, orchestratorRequest.role(), sessionId.toString(), MODEL_NAME)).thenReturn(WORKING_MEMORY);
+        when(this.promptAssembler.assemble(message, WORKING_MEMORY, List.of(), username, MEMORY_CONTEXT, RAG_CONTEXT)).thenReturn(prompt);
+        when(this.sessionMemoryService.onMessageSaved(sessionId)).thenReturn(Mono.empty());
+        when(this.memoryExtractionService.extractAndSave(userId, sessionId, message)).thenReturn(Mono.empty());
+        when(this.sessionRepository.incrementMessageCount(sessionId, 2)).thenReturn(Mono.just(1));
+
+        // When + Then
+        StepVerifier.create(this.aiOrchestrator.chat(orchestratorRequest))
+                .expectNext("Hello")
+                .expectNext(" back")
+                .verifyComplete();
+
+        ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
+        InOrder inOrder = inOrder(this.r2dbcEntityTemplate, aiProvider);
+        inOrder.verify(this.r2dbcEntityTemplate).insert(messageArgumentCaptor.capture());
+        inOrder.verify(aiProvider).streamChat(any(Prompt.class));
+
+        Message userMessage = messageArgumentCaptor.getAllValues()
+                .getFirst();
+        assertNotNull(userMessage.id());
+        assertEquals(sessionId, userMessage.sessionId());
+        assertEquals(MessageRole.USER, userMessage.role());
+        assertEquals(message, userMessage.content());
+    }
+
+    private static Stream<Arguments> provideAiProviderToModelName() {
+        return Stream.of(
+                Arguments.of(
+                        "Should call Ollama when available",
+                        mock(OllamaProvider.class), OLLAMA_MODEL_NAME),
+                Arguments.of(
+                        "Should call Gemini when available",
+                        mock(GeminiProvider.class), GEMINI_MODEL_NAME)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @DisplayName("Should call supported provided model")
+    @MethodSource("provideAiProviderToModelName")
+    void shouldCallSupportedProvidedModel(String testName, AiProvider aiProvider, String modelName) {
+        // Given
+        OrchestratorRequest orchestratorRequest = generateOrchestrationRequest();
+
+        UUID sessionId = orchestratorRequest.sessionId();
+        UUID userId = orchestratorRequest.userId();
+        String username = orchestratorRequest.username();
+        String message = orchestratorRequest.message();
+        Message userMsg = generateUserMessage(sessionId, message);
+
+        Prompt prompt = mock(Prompt.class);
+        when(aiProvider.streamChat(prompt)).thenReturn(Flux.just("Hello"," back"));
+        when(aiProvider.getModelName()).thenReturn(modelName);
+
+        when(this.r2dbcEntityTemplate.insert(any(Message.class))).thenReturn(Mono.just(userMsg));
+        when(this.sessionMemoryService.loadHistory(sessionId)).thenReturn(Mono.just(List.of()));
+        when(this.memoryService.formatForPrompt(userId, message)).thenReturn(Mono.just(MEMORY_CONTEXT));
+        when(this.ragSearchService.formatForPrompt(userId, message)).thenReturn(Mono.just(RAG_CONTEXT));
+        when(this.providerRouter.route()).thenReturn(Mono.just(aiProvider));
+        when(this.workingMemoryBuilder.build(username, orchestratorRequest.role(), sessionId.toString(), modelName)).thenReturn(WORKING_MEMORY);
+        when(this.promptAssembler.assemble(message, WORKING_MEMORY, List.of(), username, MEMORY_CONTEXT, RAG_CONTEXT)).thenReturn(prompt);
+        when(this.sessionMemoryService.onMessageSaved(sessionId)).thenReturn(Mono.empty());
+        when(this.memoryExtractionService.extractAndSave(userId, sessionId, message)).thenReturn(Mono.empty());
+        when(this.sessionRepository.incrementMessageCount(sessionId, 2)).thenReturn(Mono.just(1));
+
+        // When + Then
+        StepVerifier.create(this.aiOrchestrator.chat(orchestratorRequest))
+                .expectNext("Hello")
+                .expectNext(" back")
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Should return error flux when all providers unavailable")
+    void shouldReturnErrorFluxWhenAllProvidersUnavailable() {
+        // Given
+        RuntimeException exceptionToThrow = new RuntimeException("No AI Provider available");
+
+        OrchestratorRequest orchestratorRequest = generateOrchestrationRequest();
+
+        UUID sessionId = orchestratorRequest.sessionId();
+        UUID userId = orchestratorRequest.userId();
+        String message = orchestratorRequest.message();
+        Message userMsg = generateUserMessage(sessionId, message);
+
+        when(this.r2dbcEntityTemplate.insert(any(Message.class))).thenReturn(Mono.just(userMsg));
+        when(this.sessionMemoryService.loadHistory(sessionId)).thenReturn(Mono.just(List.of()));
+        when(this.memoryService.formatForPrompt(userId, message)).thenReturn(Mono.just(MEMORY_CONTEXT));
+        when(this.ragSearchService.formatForPrompt(userId, message)).thenReturn(Mono.just(RAG_CONTEXT));
+        when(this.providerRouter.route()).thenReturn(Mono.error(exceptionToThrow));
+        when(this.sessionMemoryService.onMessageSaved(sessionId)).thenReturn(Mono.empty());
+        when(this.memoryExtractionService.extractAndSave(userId, sessionId, message)).thenReturn(Mono.empty());
+
+        // When + Then
+        StepVerifier.create(this.aiOrchestrator.chat(orchestratorRequest))
+                .verifyErrorMatches(Predicate.isEqual(exceptionToThrow));
+    }
+
+    @Test
+    @DisplayName("Should save assistant message after stream completes")
+    void shouldSaveAssistantMessageAfterStreamCompletes() {
+        // Given
+        OrchestratorRequest orchestratorRequest = generateOrchestrationRequest();
+
+        String assistantMessageContent = "Hello back";
+        UUID sessionId = orchestratorRequest.sessionId();
+        UUID userId = orchestratorRequest.userId();
+        String username = orchestratorRequest.username();
+        String message = orchestratorRequest.message();
+
+        Message userMsg = generateUserMessage(sessionId, message);
+        Message assistantMsg = generateAssistantMessage(sessionId, assistantMessageContent, MODEL_NAME);
+
+        Prompt prompt = mock(Prompt.class);
+        AiProvider aiProvider = mock(AiProvider.class);
+        when(aiProvider.streamChat(prompt)).thenReturn(Flux.just("Hello"," back"));
+        when(aiProvider.getModelName()).thenReturn(MODEL_NAME);
+
+        when(this.r2dbcEntityTemplate.insert(any(Message.class))).thenReturn(Mono.just(userMsg)).thenReturn(Mono.just(assistantMsg));
+        when(this.sessionMemoryService.loadHistory(sessionId)).thenReturn(Mono.just(List.of()));
+        when(this.memoryService.formatForPrompt(userId, message)).thenReturn(Mono.just(MEMORY_CONTEXT));
+        when(this.ragSearchService.formatForPrompt(userId, message)).thenReturn(Mono.just(RAG_CONTEXT));
+        when(this.providerRouter.route()).thenReturn(Mono.just(aiProvider));
+        when(this.workingMemoryBuilder.build(username, orchestratorRequest.role(), sessionId.toString(), MODEL_NAME)).thenReturn(WORKING_MEMORY);
+        when(this.promptAssembler.assemble(message, WORKING_MEMORY, List.of(), username, MEMORY_CONTEXT, RAG_CONTEXT)).thenReturn(prompt);
+        when(this.sessionMemoryService.onMessageSaved(sessionId)).thenReturn(Mono.empty());
+        when(this.memoryExtractionService.extractAndSave(userId, sessionId, message)).thenReturn(Mono.empty());
+        when(this.sessionRepository.incrementMessageCount(sessionId, 2)).thenReturn(Mono.just(1));
+
+        // When + Then
+        StepVerifier.create(this.aiOrchestrator.chat(orchestratorRequest))
+                .expectNext("Hello")
+                .expectNext(" back")
+                .verifyComplete();
+
+        ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(this.r2dbcEntityTemplate, times(2)).insert(messageArgumentCaptor.capture());
+        Message assistantMessage = messageArgumentCaptor.getValue();
+        assertNotNull(assistantMessage.id());
+        assertEquals(sessionId, assistantMessage.sessionId());
+        assertEquals(MessageRole.ASSISTANT, assistantMessage.role());
+        assertEquals(assistantMessageContent, assistantMessage.content());
+    }
+
+    @Test
+    @DisplayName("Should load session history for context")
+    void shouldLoadSessionHistoryForContext() {
+        // Given
+        OrchestratorRequest orchestratorRequest = generateOrchestrationRequest();
+
+        UUID sessionId = orchestratorRequest.sessionId();
+        UUID userId = orchestratorRequest.userId();
+        String username = orchestratorRequest.username();
+        String message = orchestratorRequest.message();
+
+        Message firstHistoryMessage = generateUserMessage(sessionId, "first message");
+        Message secondHistoryMessage = generateUserMessage(sessionId, "second message");
+        List<Message> messageHistory = List.of(firstHistoryMessage, secondHistoryMessage);
+        Message userMsg = generateUserMessage(sessionId, message);
+
+        Prompt prompt = mock(Prompt.class);
+        AiProvider aiProvider = mock(AiProvider.class);
+        when(aiProvider.streamChat(prompt)).thenReturn(Flux.just("Hello"," back"));
+        when(aiProvider.getModelName()).thenReturn(MODEL_NAME);
+
+        when(this.r2dbcEntityTemplate.insert(any(Message.class))).thenReturn(Mono.just(userMsg));
+        when(this.sessionMemoryService.loadHistory(sessionId)).thenReturn(Mono.just(messageHistory));
+        when(this.memoryService.formatForPrompt(userId, message)).thenReturn(Mono.just(MEMORY_CONTEXT));
+        when(this.ragSearchService.formatForPrompt(userId, message)).thenReturn(Mono.just(RAG_CONTEXT));
+        when(this.providerRouter.route()).thenReturn(Mono.just(aiProvider));
+        when(this.workingMemoryBuilder.build(username, orchestratorRequest.role(), sessionId.toString(), MODEL_NAME)).thenReturn(WORKING_MEMORY);
+        when(this.promptAssembler.assemble(message, WORKING_MEMORY, messageHistory, username, MEMORY_CONTEXT, RAG_CONTEXT)).thenReturn(prompt);
+        when(this.sessionMemoryService.onMessageSaved(sessionId)).thenReturn(Mono.empty());
+        when(this.memoryExtractionService.extractAndSave(userId, sessionId, message)).thenReturn(Mono.empty());
+        when(this.sessionRepository.incrementMessageCount(sessionId, 2)).thenReturn(Mono.just(1));
+
+        // When + Then
+        StepVerifier.create(this.aiOrchestrator.chat(orchestratorRequest))
+                .expectNext("Hello")
+                .expectNext(" back")
+                .verifyComplete();
+    }
+
+}

--- a/server/src/test/java/ai/jarvis/ai/orchestrator/OrchestratorRequestFactory.java
+++ b/server/src/test/java/ai/jarvis/ai/orchestrator/OrchestratorRequestFactory.java
@@ -1,0 +1,21 @@
+package ai.jarvis.ai.orchestrator;
+
+import java.util.UUID;
+
+public class OrchestratorRequestFactory {
+
+    public static final String MESSAGE = "Hello";
+    public static final String USERNAME = "username";
+    public static final String ROLE = "User";
+
+    public static OrchestratorRequest generateOrchestrationRequest() {
+        return new OrchestratorRequest(
+                UUID.randomUUID(),
+                MESSAGE,
+                USERNAME,
+                ROLE,
+                UUID.randomUUID()
+                ,UUID.randomUUID()
+        );
+    }
+}

--- a/server/src/test/java/ai/jarvis/chat/message/MessageFactory.java
+++ b/server/src/test/java/ai/jarvis/chat/message/MessageFactory.java
@@ -1,0 +1,23 @@
+package ai.jarvis.chat.message;
+
+import java.util.UUID;
+
+public class MessageFactory {
+
+    public static Message generateUserMessage(UUID sessionId, String content) {
+        UUID userMsgId = UUID.randomUUID();
+        return Message.userMessage(userMsgId, sessionId, content);
+    }
+
+    public static Message generateAssistantMessage(UUID sessionId, String content, String modelName) {
+        return Message.assistantMessage(
+                UUID.randomUUID(),
+                sessionId,
+                content,
+                modelName,
+                null,
+                1000,
+                1000
+        );
+    }
+}


### PR DESCRIPTION
## What Does This PR Do?

Provided tests for `AiOrchestrator`:

- `shouldSaveUserMessage` - verififes that user message is being saved
- `shouldCallSupportedProvidedModel` - verifies that both `OllamaProvider` and `GeminiProvider` can be processed
- `shouldReturnErrorFluxWhenAllProvidersUnavailable` - verifies that exception is return when `ProviderRouter` throws an exception
- `shouldSaveAssistantMessageAfterStreamCompletes` - verifies that assistant message is saved
- `shouldLoadSessionHistoryForContext` verifies that history messages returned by `SessionMemoryService` are injected into `PromptAssembler` to be populated in prompt

---

## Related Issue

Closes #10

---

## Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [X] 🧪 Tests
* [ ] 🔧 Maintenance / chore

---

## Testing

* [X] `./mvnw test` passes
* [ ] Tested with Ollama running locally
* [ ] Tested on OS: _______________
* [X] New tests added for this change

---

## Checklist

* [X] Code follows the project coding standards
* [X] I have reviewed my own changes
* [ ] Documentation updated (if needed)
* [X] No secrets or API keys in the code
* [X] Conventional commit messages used
* [X] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)

[Add screenshots or terminal output here]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive JUnit/Mockito test suite validating chat orchestration, including ordered streaming of assistant tokens, correct persistence of user/assistant messages, and loading/session context usage.
  * Added parameterized coverage across supported provider/model combinations and verified proper error propagation on provider-router failures.
  * Introduced test utilities to quickly construct orchestration requests and user/assistant messages for use across the suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->