### PR TITLE
fix: prevent Claude Code action on fork PRs

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -17,14 +17,15 @@ jobs:
        contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues') ||
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name
-       == github.repository)
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       github.event.pull_request.user.type != 'Bot')
 
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
@@ -36,7 +37,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -17,7 +17,10 @@ jobs:
        contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' &&
        contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request')
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name
+       == github.repository)
+
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -30,6 +30,11 @@ jobs:
       id-token: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
       - name: Run Claude Code
         uses: anthropics/claude-code-action@beta
         with:


### PR DESCRIPTION
## What Does This PR Do?

Root cause (Job #82128852622):
External contributor (al-mi-8n) opened PR from fork. GitHub gives READ-ONLY GITHUB_TOKEN to fork PRs
for security. Claude Code action needs WRITE access to comment/commit → actor write permission error.

Fix: Add fork guard condition to pull_request trigger. Claude Code now only runs on:
- issue_comment with @claude mention (always)
- pull_request_review_comment with @claude (always)
- pull_request from THIS repo only (not forks)

Contributors can still trigger @claude via comments on their PRs — that path uses issue_comment which
works correctly with fork permissions.
---

## Related Issue

Closes #[issue number]

---

## Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [ ] 🧪 Tests
* [ ] 🔧 Maintenance / chore

---

## Testing

* [ ] `./mvnw test` passes
* [ ] Tested with Ollama running locally
* [ ] Tested on OS: _______________
* [ ] New tests added for this change

---

## Checklist

* [ ] Code follows the project coding standards
* [ ] I have reviewed my own changes
* [ ] Documentation updated (if needed)
* [ ] No secrets or API keys in the code
* [ ] Conventional commit messages used
* [ ] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)

[Add screenshots or terminal output here]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for improved build process handling.

---

**Note:** This release contains no user-facing changes. The update is an internal workflow configuration modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->