### PR TITLE
feat: Phase 4 Session 3 — MCP Server + builtin package

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -369,6 +369,18 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- ========================= -->
+        <!-- MCP Server (Phase 4)      -->
+        <!-- ========================= -->
+
+        <!-- Spring AI MCP Server -->
+        <!-- Exposes Jarvis tools via Model Context Protocol -->
+        <!-- External clients: Claude Desktop, VS Code AI etc. -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-mcp-server-webflux</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/server/src/main/java/ai/jarvis/tools/builtin/CalculatorTool.java
+++ b/server/src/main/java/ai/jarvis/tools/builtin/CalculatorTool.java
@@ -1,5 +1,6 @@
-package ai.jarvis.tools;
+package ai.jarvis.tools.builtin;
 
+import ai.jarvis.tools.JarvisTool;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;

--- a/server/src/main/java/ai/jarvis/tools/builtin/DateTimeTool.java
+++ b/server/src/main/java/ai/jarvis/tools/builtin/DateTimeTool.java
@@ -1,5 +1,6 @@
-package ai.jarvis.tools;
+package ai.jarvis.tools.builtin;
 
+import ai.jarvis.tools.JarvisTool;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;

--- a/server/src/main/java/ai/jarvis/tools/builtin/WeatherTool.java
+++ b/server/src/main/java/ai/jarvis/tools/builtin/WeatherTool.java
@@ -1,5 +1,6 @@
-package ai.jarvis.tools;
+package ai.jarvis.tools.builtin;
 
+import ai.jarvis.tools.JarvisTool;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.tool.annotation.Tool;

--- a/server/src/main/java/ai/jarvis/tools/builtin/WebSearchTool.java
+++ b/server/src/main/java/ai/jarvis/tools/builtin/WebSearchTool.java
@@ -1,5 +1,6 @@
-package ai.jarvis.tools;
+package ai.jarvis.tools.builtin;
 
+import ai.jarvis.tools.JarvisTool;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.tool.annotation.Tool;

--- a/server/src/main/java/ai/jarvis/tools/mcp/McpServerConfig.java
+++ b/server/src/main/java/ai/jarvis/tools/mcp/McpServerConfig.java
@@ -1,0 +1,77 @@
+package ai.jarvis.tools.mcp;
+
+import ai.jarvis.tools.ToolRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.ai.tool.method.MethodToolCallbackProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * MCP Server Configuration for Jarvis.
+ *
+ * Exposes Jarvis built-in tools as MCP ToolCallbackProvider.
+ * External MCP clients (Claude Desktop, IDEs, etc.)
+ * can connect and use all Jarvis tools via MCP protocol.
+ *
+ * Source: Official Spring AI docs + Baeldung:
+ * @Bean ToolCallbackProvider tools() {
+ *     return MethodToolCallbackProvider.builder()
+ *             .toolObjects(myTool1, myTool2)
+ *             .build();
+ * }
+ *
+ * WHY MethodToolCallbackProvider:
+ * → Scans @Tool annotated methods on provided objects
+ * → Generates JSON schema automatically
+ * → Registers them with MCP server at startup
+ * → Works with Spring AI 2.0.0-M8 API
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class McpServerConfig {
+
+    private final ToolRegistry toolRegistry;
+
+    /**
+     * Register all Jarvis tools as MCP ToolCallbackProvider.
+     *
+     * MethodToolCallbackProvider scans @Tool annotated
+     * methods on each JarvisTool instance and exposes
+     * them via the MCP protocol.
+     *
+     * Spring AI MCP Server auto-discovers beans of
+     * type ToolCallbackProvider at startup.
+     *
+     * @return ToolCallbackProvider with all built-in tools
+     */
+    @Bean
+    public ToolCallbackProvider jarvisToolCallbacks() {
+
+        if (!toolRegistry.hasTools()) {
+            log.info(
+                    "MCP Server: no tools registered");
+            return MethodToolCallbackProvider
+                    .builder()
+                    .toolObjects()
+                    .build();
+        }
+
+        Object[] toolObjects =
+                toolRegistry.asArray();
+
+        ToolCallbackProvider provider =
+                MethodToolCallbackProvider
+                        .builder()
+                        .toolObjects(toolObjects)
+                        .build();
+
+        log.info(
+                "MCP Server: registered {} tool objects",
+                toolObjects.length);
+
+        return provider;
+    }
+}

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -62,6 +62,19 @@ spring:
       embedding:
         model: nomic-embed-text
 
+  # ── MCP Server (Phase 4 Session 3) ───────────
+    mcp:
+      server:
+        # Expose Jarvis tools as MCP server
+        # External clients (Claude Desktop, IDEs)
+        # can connect and use Jarvis tools
+        enabled: true
+        name: jarvis-ai-platform
+        version: 0.1.0
+        # stdio = standard input/output transport
+        # Used by Claude Desktop + most MCP clients
+        type: SYNC
+
     google:
       genai:
         # Set GEMINI_API_KEY in .env to enable Gemini

--- a/server/src/test/java/ai/jarvis/tools/ToolRegistryTest.java
+++ b/server/src/test/java/ai/jarvis/tools/ToolRegistryTest.java
@@ -1,5 +1,7 @@
 package ai.jarvis.tools;
 
+import ai.jarvis.tools.builtin.CalculatorTool;
+import ai.jarvis.tools.builtin.DateTimeTool;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/server/src/test/java/ai/jarvis/tools/builtin/CalculatorToolTest.java
+++ b/server/src/test/java/ai/jarvis/tools/builtin/CalculatorToolTest.java
@@ -1,4 +1,4 @@
-package ai.jarvis.tools;
+package ai.jarvis.tools.builtin;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/server/src/test/java/ai/jarvis/tools/builtin/DateTimeToolTest.java
+++ b/server/src/test/java/ai/jarvis/tools/builtin/DateTimeToolTest.java
@@ -1,4 +1,4 @@
-package ai.jarvis.tools;
+package ai.jarvis.tools.builtin;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/server/src/test/java/ai/jarvis/tools/builtin/WeatherToolTest.java
+++ b/server/src/test/java/ai/jarvis/tools/builtin/WeatherToolTest.java
@@ -1,4 +1,4 @@
-package ai.jarvis.tools;
+package ai.jarvis.tools.builtin;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/server/src/test/java/ai/jarvis/tools/builtin/WebSearchToolTest.java
+++ b/server/src/test/java/ai/jarvis/tools/builtin/WebSearchToolTest.java
@@ -1,4 +1,4 @@
-package ai.jarvis.tools;
+package ai.jarvis.tools.builtin;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/server/src/test/java/ai/jarvis/tools/mcp/McpServerConfigTest.java
+++ b/server/src/test/java/ai/jarvis/tools/mcp/McpServerConfigTest.java
@@ -1,0 +1,98 @@
+package ai.jarvis.tools.mcp;
+
+import ai.jarvis.tools.ToolRegistry;
+import ai.jarvis.tools.builtin.CalculatorTool;
+import ai.jarvis.tools.builtin.DateTimeTool;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.tool.ToolCallbackProvider;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("McpServerConfig Tests")
+class McpServerConfigTest {
+
+    @Test
+    @DisplayName("creates non-null provider with tools")
+    void shouldCreateNonNullProvider() {
+        DateTimeTool dateTool = new DateTimeTool();
+        CalculatorTool calcTool = new CalculatorTool();
+
+        ToolRegistry registry = new ToolRegistry(
+                List.of(dateTool, calcTool));
+
+        McpServerConfig config =
+                new McpServerConfig(registry);
+
+        ToolCallbackProvider provider =
+                config.jarvisToolCallbacks();
+
+        // Provider must exist — Spring AI MCP Server
+        // auto-discovers it at startup
+        assertThat(provider).isNotNull();
+    }
+
+    @Test
+    @DisplayName("creates provider with tool callbacks")
+    void shouldCreateProviderWithCallbacks() {
+        DateTimeTool dateTool = new DateTimeTool();
+
+        ToolRegistry registry = new ToolRegistry(
+                List.of(dateTool));
+
+        McpServerConfig config =
+                new McpServerConfig(registry);
+
+        ToolCallbackProvider provider =
+                config.jarvisToolCallbacks();
+
+        assertThat(provider).isNotNull();
+
+        // getToolCallbacks() returns ToolCallback[]
+        // DateTimeTool has 4 @Tool methods
+        // so array length should be >= 1
+        assertThat(provider.getToolCallbacks())
+                .isNotNull()
+                .isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("provider with no tools is still valid")
+    void shouldHandleEmptyToolRegistry() {
+        ToolRegistry emptyRegistry =
+                new ToolRegistry(List.of());
+
+        McpServerConfig config =
+                new McpServerConfig(emptyRegistry);
+
+        // Should not throw — empty provider is valid
+        ToolCallbackProvider provider =
+                config.jarvisToolCallbacks();
+
+        assertThat(provider).isNotNull();
+    }
+
+    @Test
+    @DisplayName("provider exposes all tool methods")
+    void shouldExposeAllToolMethods() {
+        DateTimeTool dateTool = new DateTimeTool();
+        CalculatorTool calcTool = new CalculatorTool();
+
+        ToolRegistry registry = new ToolRegistry(
+                List.of(dateTool, calcTool));
+
+        McpServerConfig config =
+                new McpServerConfig(registry);
+
+        ToolCallbackProvider provider =
+                config.jarvisToolCallbacks();
+
+        // DateTimeTool: 4 @Tool methods
+        // CalculatorTool: 3 @Tool methods
+        // Total: 7 callbacks minimum
+        assertThat(provider.getToolCallbacks().length)
+                .isGreaterThanOrEqualTo(7);
+    }
+}


### PR DESCRIPTION
Restructured tools package:
- Moved tools to tools/builtin/ (built-in tools)
- Added tools/mcp/ (MCP protocol tools)
- JarvisTool + ToolRegistry stay at tools/ root

MCP Server:
- McpServerConfig.java registers all JarvisTool beans as MCP ToolCallback array
- Spring AI MCP Server auto-exposes via protocol
- External clients (Claude Desktop, VS Code AI) can now use all Jarvis built-in tools

pom.xml:
- Added spring-ai-starter-mcp-server-webflux

application.yml:
- Added spring.ai.mcp.server config block
- enabled=true, name=jarvis-ai-platform

Tests:
- McpServerConfigTest (3 tests)

## What Does This PR Do?

[Brief description of your changes]

---

## Related Issue

Closes #[issue number]

---

## Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [ ] 🧪 Tests
* [ ] 🔧 Maintenance / chore

---

## Testing

* [ ] `./mvnw test` passes
* [ ] Tested with Ollama running locally
* [ ] Tested on OS: _______________
* [ ] New tests added for this change

---

## Checklist

* [ ] Code follows the project coding standards
* [ ] I have reviewed my own changes
* [ ] Documentation updated (if needed)
* [ ] No secrets or API keys in the code
* [ ] Conventional commit messages used
* [ ] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)

[Add screenshots or terminal output here]
