### PR TITLE
feat: Phase 6 Session 3 — AgentOrchestrator + AgentController

### DIFF
--- a/server/src/main/java/ai/jarvis/agents/AgentController.java
+++ b/server/src/main/java/ai/jarvis/agents/AgentController.java
@@ -1,0 +1,365 @@
+package ai.jarvis.agents;
+
+import ai.jarvis.common.model.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * REST API controller for the Agent System.
+ *
+ * ENDPOINTS:
+ *
+ * POST /api/v1/agents/stream
+ *   Start agent + stream events as SSE.
+ *   Client sees real-time THINK/ACT/OBSERVE/FINAL.
+ *
+ * POST /api/v1/agents
+ *   Start agent without streaming.
+ *   Returns agent ID immediately.
+ *   Client polls GET /api/v1/agents/{id} for status.
+ *
+ * GET /api/v1/agents
+ *   List all agents for authenticated user.
+ *
+ * GET /api/v1/agents/{id}
+ *   Get agent status + all steps.
+ *
+ * GET /api/v1/agents/{id}/steps
+ *   Get just the steps for an agent.
+ *
+ * DELETE /api/v1/agents/{id}
+ *   Cancel a running agent.
+ *
+ * ALL endpoints require JWT authentication.
+ * Ownership verified before any data access.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/agents")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "Bearer Auth")
+@Tag(name = "Agents",
+        description = "AI Agent System endpoints")
+public class AgentController {
+
+    private final AgentOrchestrator orchestrator;
+    private final AgentMapper agentMapper;
+
+    // ── POST /api/v1/agents/stream ────────────────
+
+    @Operation(
+            summary = "Start agent with SSE streaming",
+            description =
+                    "Start an agent task and receive "
+                            + "real-time progress as "
+                            + "Server-Sent Events. "
+                            + "Each ReACT step emitted "
+                            + "as: think/act/observe/final."
+    )
+    @PostMapping(
+            value = "/stream",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.TEXT_EVENT_STREAM_VALUE
+    )
+    public Flux<ServerSentEvent<String>> stream(
+            @Valid @RequestBody
+            AgentRequest request) {
+
+        return getUserId()
+                .flatMapMany(userId -> {
+
+                    log.info(
+                            "Agent stream started: "
+                                    + "user={} goal_chars={}",
+                            userId,
+                            request.goal().length());
+
+                    return orchestrator
+                            .startAgent(
+                                    request.goal(),
+                                    userId,
+                                    request.sessionId())
+                            .map(event ->
+                                    ServerSentEvent
+                                            .<String>builder()
+                                            // Event type = think/act/observe/final/error
+                                            .event(event.type()
+                                                    .name()
+                                                    .toLowerCase())
+                                            // Data = JSON with step info
+                                            .data(buildEventData(event))
+                                            .build())
+                            .concatWith(Flux.just(
+                                    ServerSentEvent
+                                            .<String>builder()
+                                            .event("done")
+                                            .data("[DONE]")
+                                            .build()));
+                });
+    }
+
+    // ── POST /api/v1/agents ───────────────────────
+
+    @Operation(
+            summary = "Start agent (no streaming)",
+            description =
+                    "Start an agent task and receive "
+                            + "agent ID immediately. "
+                            + "Poll GET /agents/{id} "
+                            + "for status updates."
+    )
+    @PostMapping(
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public Mono<ApiResponse<AgentResponse>>
+    startAgent(
+            @Valid @RequestBody
+            AgentRequest request) {
+
+        return getUserId()
+                .flatMap(userId -> {
+
+                    log.info(
+                            "Agent started (async): "
+                                    + "user={} "
+                                    + "goal_chars={}",
+                            userId,
+                            request.goal().length());
+
+                    // Start agent — subscribe but
+                    // don't wait for completion
+                    orchestrator
+                            .startAgent(
+                                    request.goal(),
+                                    userId,
+                                    request.sessionId())
+                            .subscribe(
+                                    null,
+                                    error -> log.error(
+                                            "Async agent error: {}",
+                                            error.getMessage()));
+
+                    // Return accepted immediately
+                    // with placeholder response
+                    Agent pending = Agent.create(
+                            userId,
+                            request.sessionId(),
+                            request.goal());
+
+                    return Mono.just(ApiResponse.ok(
+                            agentMapper.toResponse(
+                                    pending),
+                            "Agent started. "
+                                    + "Poll GET /agents/{id} "
+                                    + "for status."));
+                });
+    }
+
+    // ── GET /api/v1/agents ────────────────────────
+
+    @Operation(
+            summary = "List all my agents",
+            description =
+                    "Returns all agents for the "
+                            + "authenticated user, "
+                            + "newest first. "
+                            + "Steps not included — "
+                            + "use GET /agents/{id}."
+    )
+    @GetMapping(
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public Mono<ApiResponse<List<AgentResponse>>>
+    listAgents() {
+
+        return getUserId()
+                .flatMap(userId ->
+                        orchestrator
+                                .getUserAgents(userId)
+                                .map(agentMapper::toResponse)
+                                .collectList())
+                .map(ApiResponse::ok);
+    }
+
+    // ── GET /api/v1/agents/{id} ───────────────────
+
+    @Operation(
+            summary = "Get agent status and steps",
+            description =
+                    "Returns agent details including "
+                            + "all executed steps "
+                            + "in order."
+    )
+    @GetMapping(
+            value = "/{agentId}",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public Mono<ApiResponse<AgentResponse>>
+    getAgent(@PathVariable UUID agentId) {
+
+        return getUserId()
+                .flatMap(userId ->
+                        orchestrator
+                                .getAgent(agentId, userId))
+                .map(agentWithSteps -> {
+
+                    Agent agent =
+                            agentWithSteps.agent();
+
+                    List<AgentStepResponse> stepResponses =
+                            agentWithSteps.steps()
+                                    .stream()
+                                    .map(agentMapper
+                                            ::toStepResponse)
+                                    .toList();
+
+                    // Build response with steps
+                    AgentResponse response =
+                            new AgentResponse(
+                                    agent.id(),
+                                    agent.goal(),
+                                    agent.status(),
+                                    agent.finalAnswer(),
+                                    agent.stepCount(),
+                                    agent.errorMessage(),
+                                    agent.durationMs(),
+                                    agent.createdAt(),
+                                    agent.updatedAt(),
+                                    agent.completedAt(),
+                                    stepResponses);
+
+                    return ApiResponse.ok(response);
+                });
+    }
+
+    // ── GET /api/v1/agents/{id}/steps ─────────────
+
+    @Operation(
+            summary = "Get agent steps only",
+            description =
+                    "Returns just the execution "
+                            + "steps for an agent "
+                            + "in order."
+    )
+    @GetMapping(
+            value = "/{agentId}/steps",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public Mono<ApiResponse<List<AgentStepResponse>>>
+    getSteps(@PathVariable UUID agentId) {
+
+        return getUserId()
+                .flatMap(userId ->
+                        orchestrator
+                                .getAgent(agentId, userId))
+                .map(agentWithSteps ->
+                        agentWithSteps.steps()
+                                .stream()
+                                .map(agentMapper
+                                        ::toStepResponse)
+                                .toList())
+                .map(ApiResponse::ok);
+    }
+
+    // ── DELETE /api/v1/agents/{id} ────────────────
+
+    @Operation(
+            summary = "Cancel a running agent",
+            description =
+                    "Cancels a PENDING or RUNNING agent. "
+                            + "Cannot cancel COMPLETED, "
+                            + "FAILED, or CANCELLED agents."
+    )
+    @DeleteMapping("/{agentId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<Void> cancelAgent(
+            @PathVariable UUID agentId) {
+
+        return getUserId()
+                .flatMap(userId ->
+                        orchestrator.cancelAgent(
+                                agentId, userId));
+    }
+
+    // ── Private Helpers ───────────────────────────
+
+    /**
+     * Extract userId UUID from JWT principal.
+     * Same pattern as MemoryController + VoiceController.
+     * onErrorMap converts malformed UUID → 401.
+     */
+    private Mono<UUID> getUserId() {
+        return ReactiveSecurityContextHolder.getContext()
+                .map(SecurityContext::getAuthentication)
+                .map(Authentication::getPrincipal)
+                .cast(String.class)
+                .map(UUID::fromString)
+                .onErrorMap(
+                        IllegalArgumentException.class,
+                        ex -> new ResponseStatusException(
+                                HttpStatus.UNAUTHORIZED,
+                                "Invalid token subject"));
+    }
+
+    /**
+     * Build SSE event data string from AgentEvent.
+     *
+     * Format: JSON with step, data, and tool fields.
+     * Simple manual JSON — no Jackson needed for this.
+     *
+     * @param event the agent event to serialize
+     * @return JSON string for SSE data field
+     */
+    private String buildEventData(AgentEvent event) {
+        StringBuilder json = new StringBuilder("{");
+        json.append("\"step\":").append(event.stepIndex());
+        json.append(",\"data\":\"")
+                .append(escapeJson(event.data()))
+                .append("\"");
+
+        if (event.toolName() != null) {
+            json.append(",\"tool\":\"")
+                    .append(event.toolName())
+                    .append("\"");
+        }
+
+        json.append("}");
+        return json.toString();
+    }
+
+    /**
+     * Escape special characters for JSON string values.
+     * Prevents malformed JSON when data contains quotes.
+     *
+     * @param text raw text to escape
+     * @return JSON-safe escaped string
+     */
+    private String escapeJson(String text) {
+        if (text == null) return "";
+        return text
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+}

--- a/server/src/main/java/ai/jarvis/agents/AgentMapper.java
+++ b/server/src/main/java/ai/jarvis/agents/AgentMapper.java
@@ -1,0 +1,58 @@
+package ai.jarvis.agents;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+
+/**
+ * MapStruct mapper for Agent entities.
+ *
+ * Converts Agent + AgentStep to their
+ * response DTOs for REST API output.
+ *
+ * toResponse(Agent):
+ * Produces AgentResponse with steps=null.
+ * Used for list endpoint — no step loading needed.
+ * steps must be explicitly ignored because
+ * AgentResponse has a steps field but Agent does not.
+ *
+ * toStepResponse(AgentStep):
+ * Produces AgentStepResponse from a single step.
+ * AgentStep.input is automatically excluded because
+ * AgentStepResponse does NOT have an input field.
+ * MapStruct only maps fields that exist in BOTH
+ * source and target — no @Mapping needed to exclude.
+ */
+@Mapper(componentModel =
+        MappingConstants.ComponentModel.SPRING)
+public interface AgentMapper {
+
+    /**
+     * Convert Agent to response without steps.
+     *
+     * @Mapping(target = "steps") required because
+     * AgentResponse.steps exists but Agent.steps does not.
+     * MapStruct would fail without this ignore.
+     *
+     * @param agent the agent entity
+     * @return AgentResponse with steps=null
+     */
+    @Mapping(target = "steps", ignore = true)
+    AgentResponse toResponse(Agent agent);
+
+    /**
+     * Convert AgentStep to step response.
+     *
+     * AgentStep.input is NOT mapped because
+     * AgentStepResponse has no "input" field.
+     * MapStruct skips source fields with no
+     * matching target field automatically.
+     *
+     * No @Mapping annotations needed here —
+     * all field names match between source and target.
+     *
+     * @param step the agent step entity
+     * @return AgentStepResponse
+     */
+    AgentStepResponse toStepResponse(AgentStep step);
+}

--- a/server/src/main/java/ai/jarvis/agents/AgentOrchestrator.java
+++ b/server/src/main/java/ai/jarvis/agents/AgentOrchestrator.java
@@ -1,0 +1,298 @@
+package ai.jarvis.agents;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Coordinates the full agent lifecycle.
+ *
+ * RESPONSIBILITIES:
+ * 1. Create Agent entity in DB (PENDING)
+ * 2. Transition to RUNNING
+ * 3. Delegate execution to AgentExecutor
+ * 4. Monitor event stream for FINAL/ERROR
+ * 5. Update Agent to COMPLETED or FAILED
+ * 6. Return Flux<AgentEvent> for SSE streaming
+ *
+ * WHY separate from AgentExecutor:
+ * AgentExecutor handles the ReACT loop only.
+ * AgentOrchestrator handles the DB lifecycle:
+ * create → run → complete/fail.
+ * Separation keeps each class focused.
+ *
+ * STREAMING:
+ * Returns the Flux<AgentEvent> directly so
+ * AgentController can stream events to the client
+ * while the agent executes in the background.
+ * The doOnNext/doOnComplete/doOnError side effects
+ * update the DB without blocking the stream.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AgentOrchestrator {
+
+    private final AgentExecutor executor;
+    private final AgentRepository agentRepository;
+    private final AgentStepRepository stepRepository;
+    private final R2dbcEntityTemplate r2dbcEntityTemplate;
+
+    /**
+     * Start an agent task and stream its events.
+     *
+     * FLOW:
+     * 1. Create Agent (PENDING) in DB
+     * 2. Transition to RUNNING in DB
+     * 3. Start AgentExecutor loop
+     * 4. Stream events to caller
+     * 5. On FINAL event → update DB to COMPLETED
+     * 6. On ERROR event → update DB to FAILED
+     *
+     * The returned Flux is cold — execution only
+     * starts when someone subscribes to it
+     * (when the SSE connection is established).
+     *
+     * @param goal      user's task description
+     * @param userId    authenticated user
+     * @param sessionId optional chat session link
+     * @return Flux<AgentEvent> streamed step events
+     */
+    public Flux<AgentEvent> startAgent(
+            String goal,
+            UUID userId,
+            UUID sessionId) {
+
+        long startTime =
+                System.currentTimeMillis();
+
+        // Create + persist Agent entity
+        Agent newAgent = Agent.create(
+                userId, sessionId, goal);
+
+        return r2dbcEntityTemplate
+                .insert(newAgent)
+                // Transition to RUNNING
+                .flatMap(agent ->
+                        r2dbcEntityTemplate
+                                .update(agent.withRunning()))
+                .doOnSuccess(agent ->
+                        log.info(
+                                "Agent started: id={} "
+                                        + "user={}",
+                                agent.id(), userId))
+                .flatMapMany(agent ->
+
+                        // Execute the ReACT loop
+                        executor.execute(agent, userId)
+
+                                // Track FINAL event to
+                                // update DB to COMPLETED
+                                .doOnNext(event -> {
+
+                                    if (event.type() ==
+                                            AgentEvent.EventType.FINAL) {
+
+                                        long duration =
+                                                System.currentTimeMillis()
+                                                        - startTime;
+
+                                        // Async DB update
+                                        // count steps then complete
+                                        stepRepository
+                                                .countByAgentId(
+                                                        agent.id())
+                                                .flatMap(count ->
+                                                        agentRepository
+                                                                .updateStatus(
+                                                                        agent.id(),
+                                                                        AgentStatus.RUNNING.name(),
+                                                                        AgentStatus.COMPLETED.name(),
+                                                                        count.intValue(),
+                                                                        event.data(),
+                                                                        null))
+                                                .doOnSuccess(rows -> {
+                                                    if (rows > 0) {
+                                                        log.info(
+                                                                "Agent COMPLETED: "
+                                                                        + "id={} "
+                                                                        + "duration={}ms",
+                                                                agent.id(),
+                                                                duration);
+                                                    } else {
+                                                        log.warn(
+                                                                "Agent COMPLETED "
+                                                                        + "but 0 rows updated "
+                                                                        + "(race condition?): "
+                                                                        + "id={}",
+                                                                agent.id());
+                                                    }
+                                                })
+                                                .doOnError(e ->
+                                                        log.error(
+                                                                "Failed to complete "
+                                                                        + "agent: id={} "
+                                                                        + "error={}",
+                                                                agent.id(),
+                                                                e.getMessage()))
+                                                .subscribe();
+                                    }
+                                })
+
+                                // On ERROR event → FAILED
+                                .doOnNext(event -> {
+                                    if (event.type() ==
+                                            AgentEvent.EventType.ERROR) {
+
+                                        agentRepository
+                                                .updateStatus(
+                                                        agent.id(),
+                                                        AgentStatus.RUNNING.name(),
+                                                        AgentStatus.FAILED.name(),
+                                                        agent.stepCount(),
+                                                        null,
+                                                        event.data())
+                                                .doOnError(e ->
+                                                        log.error(
+                                                                "Failed to mark agent "
+                                                                        + "as FAILED: id={}",
+                                                                agent.id()))
+                                                .subscribe();
+                                    }
+                                })
+
+                                // On stream error → FAILED
+                                .doOnError(error -> {
+                                    log.error(
+                                            "Agent stream error: "
+                                                    + "id={} error={}",
+                                            agent.id(),
+                                            error.getMessage());
+
+                                    agentRepository
+                                            .updateStatus(
+                                                    agent.id(),
+                                                    AgentStatus.RUNNING.name(),
+                                                    AgentStatus.FAILED.name(),
+                                                    agent.stepCount(),
+                                                    null,
+                                                    error.getMessage())
+                                            .subscribe();
+                                })
+                );
+    }
+
+    /**
+     * Get all agents for a user (newest first).
+     * Steps NOT loaded — use getAgent() for steps.
+     *
+     * @param userId authenticated user
+     * @return Flux<Agent> agents without steps
+     */
+    public Flux<Agent> getUserAgents(UUID userId) {
+        return agentRepository
+                .findByUserIdOrderByCreatedAtDesc(
+                        userId);
+    }
+
+    /**
+     * Get a single agent with its steps.
+     * Ownership verified — 404 if not found or wrong user.
+     *
+     * @param agentId the agent to retrieve
+     * @param userId  must be the owner
+     * @return Mono<AgentWithSteps> agent + ordered steps
+     */
+    public Mono<AgentWithSteps> getAgent(
+            UUID agentId, UUID userId) {
+
+        return agentRepository
+                .findByIdAndUserId(agentId, userId)
+                .switchIfEmpty(Mono.error(
+                        new ResponseStatusException(
+                                HttpStatus.NOT_FOUND,
+                                "Agent not found")))
+                .flatMap(agent ->
+                        stepRepository
+                                .findByAgentIdOrderByStepIndexAsc(
+                                        agentId)
+                                .collectList()
+                                .map(steps ->
+                                        new AgentWithSteps(
+                                                agent, steps)));
+    }
+
+    /**
+     * Cancel a running agent.
+     * Can only cancel PENDING or RUNNING agents.
+     * Ownership verified before cancellation.
+     *
+     * @param agentId agent to cancel
+     * @param userId  must be the owner
+     * @return Mono<Void> completes when cancelled
+     */
+    public Mono<Void> cancelAgent(
+            UUID agentId, UUID userId) {
+
+        return agentRepository
+                .findByIdAndUserId(agentId, userId)
+                .switchIfEmpty(Mono.error(
+                        new ResponseStatusException(
+                                HttpStatus.NOT_FOUND,
+                                "Agent not found")))
+                .flatMap(agent -> {
+
+                    // Can only cancel non-terminal agents
+                    if (agent.status() ==
+                            AgentStatus.COMPLETED
+                            || agent.status() ==
+                            AgentStatus.FAILED
+                            || agent.status() ==
+                            AgentStatus.CANCELLED) {
+
+                        return Mono.error(
+                                new ResponseStatusException(
+                                        HttpStatus.CONFLICT,
+                                        "Agent is already "
+                                                + "in terminal state: "
+                                                + agent.status()));
+                    }
+
+                    log.info(
+                            "Cancelling agent: id={} "
+                                    + "user={}",
+                            agentId, userId);
+
+                    return agentRepository
+                            .updateStatus(
+                                    agentId,
+                                    agent.status().name(),
+                                    AgentStatus.CANCELLED.name(),
+                                    agent.stepCount(),
+                                    null,
+                                    null)
+                            .then();
+                });
+    }
+
+    // ── Inner Record ──────────────────────────────
+
+    /**
+     * Agent + its steps combined.
+     * Used for single agent detail endpoint.
+     *
+     * @param agent the agent entity
+     * @param steps all steps in order
+     */
+    public record AgentWithSteps(
+            Agent agent,
+            List<AgentStep> steps) {}
+}

--- a/server/src/main/java/ai/jarvis/agents/AgentRequest.java
+++ b/server/src/main/java/ai/jarvis/agents/AgentRequest.java
@@ -1,0 +1,29 @@
+package ai.jarvis.agents;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+/**
+ * Request body for starting an agent task.
+ *
+ * POST /api/v1/agents
+ * POST /api/v1/agents/stream
+ *
+ * goal is the user's natural language task description.
+ * sessionId optionally links the agent to a chat session
+ * so the AI has access to conversation context.
+ */
+public record AgentRequest(
+
+        @NotBlank(message = "Goal cannot be empty")
+        @Size(max = 2000,
+                message = "Goal too long (max 2000 chars)")
+        String goal,
+
+        // Optional: link to existing chat session
+        // null = standalone agent task
+        UUID sessionId
+
+) {}

--- a/server/src/main/java/ai/jarvis/agents/AgentResponse.java
+++ b/server/src/main/java/ai/jarvis/agents/AgentResponse.java
@@ -1,0 +1,44 @@
+package ai.jarvis.agents;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * DTO for exposing agent data via REST API.
+ *
+ * Two variants:
+ * - Without steps: used for list endpoint
+ * - With steps: used for single agent detail
+ *
+ * steps is null when not requested (list view)
+ * to avoid loading all steps for every agent in a list.
+ */
+public record AgentResponse(
+
+        UUID id,
+
+        String goal,
+
+        AgentStatus status,
+
+        // The synthesized answer
+        // null while PENDING or RUNNING
+        String finalAnswer,
+
+        int stepCount,
+
+        // Error message if FAILED
+        String errorMessage,
+
+        Integer durationMs,
+
+        Instant createdAt,
+        Instant updatedAt,
+        Instant completedAt,
+
+        // Only populated for single agent detail
+        // null for list endpoint (performance)
+        List<AgentStepResponse> steps
+
+) {}

--- a/server/src/main/java/ai/jarvis/agents/AgentStepResponse.java
+++ b/server/src/main/java/ai/jarvis/agents/AgentStepResponse.java
@@ -1,0 +1,40 @@
+package ai.jarvis.agents;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * DTO for exposing agent steps via REST API.
+ *
+ * Does NOT expose input field to avoid
+ * leaking potentially sensitive prompt content.
+ * Only exposes what users need to see:
+ * step type, tool used, output, timing.
+ */
+public record AgentStepResponse(
+
+        UUID id,
+
+        int stepIndex,
+
+        AgentStepType stepType,
+
+        // Which tool was called (ACT steps only)
+        // null for THINK, OBSERVE, FINAL
+        String toolName,
+
+        // What this step produced:
+        // THINK: AI reasoning
+        // OBSERVE: tool result
+        // FINAL: final answer
+        // ACT: null (result in OBSERVE)
+        String output,
+
+        AgentStepStatus status,
+
+        Integer durationMs,
+
+        Instant createdAt,
+        Instant completedAt
+
+) {}

--- a/server/src/test/java/ai/jarvis/agents/AgentOrchestratorTest.java
+++ b/server/src/test/java/ai/jarvis/agents/AgentOrchestratorTest.java
@@ -1,0 +1,261 @@
+package ai.jarvis.agents;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AgentOrchestrator Tests")
+class AgentOrchestratorTest {
+
+    @Mock
+    private AgentExecutor executor;
+
+    @Mock
+    private AgentRepository agentRepository;
+
+    @Mock
+    private AgentStepRepository stepRepository;
+
+    @Mock
+    private R2dbcEntityTemplate r2dbcEntityTemplate;
+
+    private AgentOrchestrator orchestrator;
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        orchestrator = new AgentOrchestrator(
+                executor,
+                agentRepository,
+                stepRepository,
+                r2dbcEntityTemplate);
+
+        userId = UUID.randomUUID();
+    }
+
+    // ── startAgent() tests ────────────────────────
+
+    @Test
+    @DisplayName("startAgent() creates PENDING then RUNNING agent")
+    void shouldCreateAndRunAgent() {
+        Agent pendingAgent = Agent.create(
+                userId, null, "Test goal");
+        Agent runningAgent =
+                pendingAgent.withRunning();
+
+        // DB insert → returns pendingAgent
+        when(r2dbcEntityTemplate
+                .insert(any(Agent.class)))
+                .thenReturn(Mono.just(pendingAgent));
+
+        // DB update to RUNNING → returns runningAgent
+        when(r2dbcEntityTemplate
+                .update(any(Agent.class)))
+                .thenReturn(Mono.just(runningAgent));
+
+        // Executor returns immediate FINAL event
+        when(executor.execute(
+                any(Agent.class), any(UUID.class)))
+                .thenReturn(Flux.just(
+                        AgentEvent.finalAnswer(
+                                0, "Done!")));
+
+        // DB update to COMPLETED
+        when(stepRepository
+                .countByAgentId(any(UUID.class)))
+                .thenReturn(Mono.just(1L));
+
+        when(agentRepository.updateStatus(
+                any(), anyString(), anyString(),
+                anyInt(), anyString(), isNull()))
+                .thenReturn(Mono.just(1));
+
+        StepVerifier
+                .create(orchestrator.startAgent(
+                        "Test goal", userId, null))
+                .expectNextMatches(event ->
+                        event.type() ==
+                                AgentEvent.EventType.FINAL
+                                && event.data()
+                                .equals("Done!"))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("startAgent() marks agent FAILED on error event")
+    void shouldMarkFailedOnErrorEvent() {
+        Agent pendingAgent = Agent.create(
+                userId, null, "Test goal");
+        Agent runningAgent =
+                pendingAgent.withRunning();
+
+        when(r2dbcEntityTemplate
+                .insert(any(Agent.class)))
+                .thenReturn(Mono.just(pendingAgent));
+        when(r2dbcEntityTemplate
+                .update(any(Agent.class)))
+                .thenReturn(Mono.just(runningAgent));
+
+        // Executor returns ERROR event
+        when(executor.execute(
+                any(Agent.class), any(UUID.class)))
+                .thenReturn(Flux.just(
+                        AgentEvent.error("AI failed")));
+
+        when(agentRepository.updateStatus(
+                any(), anyString(), anyString(),
+                anyInt(), isNull(), anyString()))
+                .thenReturn(Mono.just(1));
+
+        StepVerifier
+                .create(orchestrator.startAgent(
+                        "Test goal", userId, null))
+                .expectNextMatches(event ->
+                        event.type() ==
+                                AgentEvent.EventType.ERROR)
+                .verifyComplete();
+    }
+
+    // ── getUserAgents() tests ─────────────────────
+
+    @Test
+    @DisplayName("getUserAgents() returns all user agents")
+    void shouldReturnUserAgents() {
+        Agent agent1 = Agent.create(
+                userId, null, "Task 1");
+        Agent agent2 = Agent.create(
+                userId, null, "Task 2");
+
+        when(agentRepository
+                .findByUserIdOrderByCreatedAtDesc(
+                        userId))
+                .thenReturn(
+                        Flux.just(agent1, agent2));
+
+        StepVerifier
+                .create(orchestrator
+                        .getUserAgents(userId))
+                .expectNext(agent1)
+                .expectNext(agent2)
+                .verifyComplete();
+    }
+
+    // ── getAgent() tests ──────────────────────────
+
+    @Test
+    @DisplayName("getAgent() returns agent with steps")
+    void shouldReturnAgentWithSteps() {
+        Agent agent = Agent.create(
+                userId, null, "Test goal");
+
+        AgentStep step = AgentStep.createFinal(
+                agent.id(), userId, 0, "Done");
+
+        when(agentRepository
+                .findByIdAndUserId(
+                        agent.id(), userId))
+                .thenReturn(Mono.just(agent));
+
+        when(stepRepository
+                .findByAgentIdOrderByStepIndexAsc(
+                        agent.id()))
+                .thenReturn(Flux.just(step));
+
+        StepVerifier
+                .create(orchestrator.getAgent(
+                        agent.id(), userId))
+                .expectNextMatches(aws ->
+                        aws.agent().id()
+                                .equals(agent.id())
+                                && aws.steps().size() == 1)
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("getAgent() returns 404 when not found")
+    void shouldReturn404WhenNotFound() {
+        UUID agentId = UUID.randomUUID();
+
+        when(agentRepository
+                .findByIdAndUserId(
+                        agentId, userId))
+                .thenReturn(Mono.empty());
+
+        StepVerifier
+                .create(orchestrator.getAgent(
+                        agentId, userId))
+                .expectErrorMatches(error ->
+                        error instanceof
+                                ResponseStatusException rse
+                                && rse.getStatusCode()
+                                .value() == 404)
+                .verify();
+    }
+
+    // ── cancelAgent() tests ───────────────────────
+
+    @Test
+    @DisplayName("cancelAgent() cancels RUNNING agent")
+    void shouldCancelRunningAgent() {
+        Agent running = Agent.create(
+                        userId, null, "Test goal")
+                .withRunning();
+
+        when(agentRepository
+                .findByIdAndUserId(
+                        running.id(), userId))
+                .thenReturn(Mono.just(running));
+
+        when(agentRepository.updateStatus(
+                any(), anyString(), anyString(),
+                anyInt(), isNull(), isNull()))
+                .thenReturn(Mono.just(1));
+
+        StepVerifier
+                .create(orchestrator.cancelAgent(
+                        running.id(), userId))
+                .verifyComplete();
+    }
+
+    @Test
+    @DisplayName("cancelAgent() returns 409 for terminal agent")
+    void shouldReturn409ForTerminalAgent() {
+        Agent completed = Agent.create(
+                        userId, null, "Test goal")
+                .withRunning()
+                .withCompleted("Done", 1, 100);
+
+        when(agentRepository
+                .findByIdAndUserId(
+                        completed.id(), userId))
+                .thenReturn(Mono.just(completed));
+
+        StepVerifier
+                .create(orchestrator.cancelAgent(
+                        completed.id(), userId))
+                .expectErrorMatches(error ->
+                        error instanceof
+                                ResponseStatusException rse
+                                && rse.getStatusCode()
+                                .value() == 409)
+                .verify();
+    }
+}


### PR DESCRIPTION
DTOs:
- AgentRequest: goal + optional sessionId
- AgentStepResponse: step details (input excluded)
- AgentResponse: agent status + optional steps list

AgentMapper (MapStruct):
- toResponse(): Agent → AgentResponse (steps=null)
- toStepResponse(): AgentStep → AgentStepResponse

AgentOrchestrator:
- startAgent(): create PENDING → RUNNING → stream events On FINAL event → async update to COMPLETED On ERROR event → async update to FAILED compare-and-set via updateStatus(expectedCurrentStatus)
- getUserAgents(): list all user agents newest first
- getAgent(): single agent + steps (ownership verified)
- cancelAgent(): PENDING/RUNNING → CANCELLED Returns 409 for terminal agents Returns 404 if not found or wrong owner
- AgentWithSteps inner record

AgentController:
- POST /api/v1/agents/stream (SSE streaming)
- POST /api/v1/agents (async, returns immediately)
- GET  /api/v1/agents (list)
- GET  /api/v1/agents/{id} (detail + steps)
- GET  /api/v1/agents/{id}/steps (steps only)
- DELETE /api/v1/agents/{id} (cancel)
- getUserId() with onErrorMap → 401
- buildEventData() JSON serialization

Tests:
- AgentOrchestratorTest (7 tests)

## What Does This PR Do?

[Brief description of your changes]

---

## Related Issue

Closes #[issue number]

---

## Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [ ] 🧪 Tests
* [ ] 🔧 Maintenance / chore

---

## Testing

* [ ] `./mvnw test` passes
* [ ] Tested with Ollama running locally
* [ ] Tested on OS: _______________
* [ ] New tests added for this change

---

## Checklist

* [ ] Code follows the project coding standards
* [ ] I have reviewed my own changes
* [ ] Documentation updated (if needed)
* [ ] No secrets or API keys in the code
* [ ] Conventional commit messages used
* [ ] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)

[Add screenshots or terminal output here]
