### PR TITLE
Added the tokens count and seconds to the CLI display.

### DIFF
--- a/server/src/main/java/ai/jarvis/cli/ChatCommands.java
+++ b/server/src/main/java/ai/jarvis/cli/ChatCommands.java
@@ -167,8 +167,14 @@ public class ChatCommands {
                     System.out.print(token);
                     System.out.flush();
                 },
-                () -> {
+                stats -> {
                     System.out.println();
+                    if (stats.tokenCount() > 0) {
+                        System.out.printf(
+                                "── %d tokens · %.1fs ──%n",
+                                stats.tokenCount(),
+                                stats.durationSeconds());
+                    }
                     System.out.println();
                     System.out.flush();
                 },

--- a/server/src/main/java/ai/jarvis/cli/CliHttpClient.java
+++ b/server/src/main/java/ai/jarvis/cli/CliHttpClient.java
@@ -123,7 +123,7 @@ public class CliHttpClient {
             Object body,
             java.util.function.Consumer<String> onSession,
             java.util.function.Consumer<String> onToken,
-            Runnable onDone,
+            java.util.function.Consumer<StreamStats> onDone,
             java.util.function.Consumer<String> onError) {
 
         try {
@@ -132,6 +132,9 @@ public class CliHttpClient {
                     .WebClient.builder()
                     .baseUrl(BASE_URL)
                     .build();
+
+            long startNanos = System.nanoTime();
+            int[] tokenCount = {0};
 
             webClient
                     .post()
@@ -161,10 +164,14 @@ public class CliHttpClient {
                             String tokenText =
                                     parseJsonToken(event.data());
                             if (tokenText != null) {
+                                tokenCount[0]++;
                                 onToken.accept(tokenText);
                             }
                         } else if ("done".equals(eventType)) {
-                            onDone.run();
+                            double seconds = (System.nanoTime() - startNanos)
+                                    / 1_000_000_000.0;
+                            onDone.accept(new StreamStats(
+                                    tokenCount[0], seconds));
                         }
                     })
                     .doOnError(err ->

--- a/server/src/main/java/ai/jarvis/cli/StreamStats.java
+++ b/server/src/main/java/ai/jarvis/cli/StreamStats.java
@@ -1,0 +1,4 @@
+package ai.jarvis.cli;
+
+public record StreamStats(int tokenCount, double durationSeconds) {
+}


### PR DESCRIPTION
## What Does This PR Do?

After each AI response in chat, display token count and response time.

---

## Related Issue

[Closes #[3]](https://github.com/issues/assigned?issue=sujankim%7Cjarvis-ai-platform%7C3)

---

## Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [ ] 🧪 Tests
* [x] 🔧 Maintenance / chore

---

## Testing

* [x] `./mvnw test` passes
* [x] Tested with Ollama running locally
* [x] Tested on OS: Mac
* [ ] New tests added for this change

---

## Checklist

* [x] Code follows the project coding standards
* [x] I have reviewed my own changes
* [ ] Documentation updated (if needed)
* [x] No secrets or API keys in the code
* [x] Conventional commit messages used
* [x] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)
All tests are passing:
<img width="635" height="196" alt="Screenshot 2026-06-30 at 2 58 15 PM" src="https://github.com/user-attachments/assets/c8c3e0d1-d834-4fb5-94b8-c9d58dd2e055" />
Displays the token count and time
<img width="1260" height="273" alt="Screenshot 2026-06-30 at 2 48 17 PM" src="https://github.com/user-attachments/assets/5a7a3dd8-a6be-482d-be67-f74cf6fa54e6" />


[Add screenshots or terminal output here]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming chat responses now include a brief end-of-stream summary with token count and total elapsed time when available.
  * The CLI now reports stream statistics after a chat completes, making it easier to track response size and duration.

* **Bug Fixes**
  * Improved completion handling so streaming output finishes with a clearer final status instead of a blank callback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->