### PR TITLE
chore: upgrade GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-      #  add Redis service so context loads correctly
       redis:
         image: redis:7-alpine
         ports:
@@ -47,9 +46,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        # Updated: v4.2.2 → v6
+        # Stable major version, well-tested
+        # Skip v7 for now (new fork PR restrictions in v7)
+        uses: actions/checkout@v6
 
       - name: Set up Java 21
+        # Already upgraded to v5.4.0 via PR #101
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
@@ -73,7 +76,10 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        # Updated: v4.6.2 → v5
+        # One major version at a time
+        # v6/v7 require Node.js 24 runner — upgrade later
+        uses: actions/upload-artifact@v5
         with:
           name: test-results
           path: server/target/surefire-reports/


### PR DESCRIPTION
- actions/checkout: v4.2.2 → v6 Stable, well-tested major version Skip v7 for now (new fork PR checkout restrictions)

- actions/upload-artifact: v4.6.2 → v5 One major version at a time v6/v7 require Node.js 24 runner minimum Upgrade to v6 → v7 in future maintenance

- actions/setup-java: already at v5.4.0 (PR #101)
- claude-code.yml: already at checkout@v6 (no change)

## What Does This PR Do?

[Brief description of your changes]

---

## Related Issue

Closes #[issue number]

---

## Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [ ] 🧪 Tests
* [ ] 🔧 Maintenance / chore

---

## Testing

* [ ] `./mvnw test` passes
* [ ] Tested with Ollama running locally
* [ ] Tested on OS: _______________
* [ ] New tests added for this change

---

## Checklist

* [ ] Code follows the project coding standards
* [ ] I have reviewed my own changes
* [ ] Documentation updated (if needed)
* [ ] No secrets or API keys in the code
* [ ] Conventional commit messages used
* [ ] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)

[Add screenshots or terminal output here]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the CI test environment by adding a Redis service, helping tests run more reliably.
  * Updated GitHub Actions versions used in CI to stay on supported releases and improve maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->