### PR TITLE
feat: Backend: GET /api/v1/documents/{id}/status endpoint  #95

### DIFF
--- a/server/src/main/java/ai/jarvis/agents/Agent.java
+++ b/server/src/main/java/ai/jarvis/agents/Agent.java
@@ -144,7 +144,7 @@ public record Agent(
                 null,           // no error
                 totalDurationMs,
                 createdAt, Instant.now(),
-                Instant.now()); // updatedAt = now
+                Instant.now()); // completedAt   = now
     }
 
     /**

--- a/server/src/main/java/ai/jarvis/agents/Agent.java
+++ b/server/src/main/java/ai/jarvis/agents/Agent.java
@@ -144,7 +144,7 @@ public record Agent(
                 null,           // no error
                 totalDurationMs,
                 createdAt, Instant.now(),
-                Instant.now()); // completedAt = now
+                Instant.now()); // updatedAt = now
     }
 
     /**

--- a/server/src/main/java/ai/jarvis/common/util/SecurityUtil.java
+++ b/server/src/main/java/ai/jarvis/common/util/SecurityUtil.java
@@ -1,0 +1,20 @@
+package ai.jarvis.common.util;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+public class SecurityUtil {
+
+    public static Mono<UUID> getUserId(Mono<Authentication> authenticationMono) {
+        return authenticationMono
+                .map(Authentication::getPrincipal)
+                .cast(String.class)
+                .map(UUID::fromString)
+                .onErrorMap(IllegalArgumentException.class,
+                        ex -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token subject", ex));
+    }
+}

--- a/server/src/main/java/ai/jarvis/rag/DocumentController.java
+++ b/server/src/main/java/ai/jarvis/rag/DocumentController.java
@@ -1,0 +1,62 @@
+package ai.jarvis.rag;
+
+import java.util.UUID;
+
+import ai.jarvis.common.model.ApiResponse;
+import ai.jarvis.common.model.ErrorResponse;
+import ai.jarvis.common.util.SecurityUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequiredArgsConstructor
+@SecurityRequirement(name = "Bearer Auth")
+@Tag(name = "Document", description = "Document Management")
+@RequestMapping("/api/v1/documents")
+class DocumentController {
+    private final DocumentService documentService;
+
+    @Operation(summary = "Get document status")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "Successfully retrieved document status"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid document id",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "Invalid or no token provided",
+                    content = @Content(schema = @Schema(hidden = true))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "Document was not found by given id",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @GetMapping(value = "/{documentId}/status", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ApiResponse<DocumentStatusResponse>> getDocumentStatus(
+            @PathVariable UUID documentId,
+            @Parameter(hidden = true) Mono<Authentication> authenticationMono) {
+        return SecurityUtil.getUserId(authenticationMono)
+                .flatMap(userId -> documentService.getDocumentByIdAndUserId(documentId, userId))
+                .map(ApiResponse::ok);
+    }
+}

--- a/server/src/main/java/ai/jarvis/rag/DocumentController.java
+++ b/server/src/main/java/ai/jarvis/rag/DocumentController.java
@@ -26,7 +26,7 @@ import reactor.core.publisher.Mono;
 @SecurityRequirement(name = "Bearer Auth")
 @Tag(name = "Document", description = "Document Management")
 @RequestMapping("/api/v1/documents")
-class DocumentController {
+public class DocumentController {
     private final DocumentService documentService;
 
     @Operation(summary = "Get document status")

--- a/server/src/main/java/ai/jarvis/rag/DocumentService.java
+++ b/server/src/main/java/ai/jarvis/rag/DocumentService.java
@@ -1,0 +1,30 @@
+package ai.jarvis.rag;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import reactor.core.publisher.Mono;
+
+@Service
+public class DocumentService {
+    private final DocumentRepository documentRepository;
+
+    public DocumentService(DocumentRepository documentRepository) {
+        this.documentRepository = documentRepository;
+    }
+
+    public Mono<DocumentStatusResponse> getDocumentByIdAndUserId(UUID documentId, UUID userId) {
+        return documentRepository.findByIdAndUserId(documentId, userId)
+                .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND, "Document not found")))
+                .map(it -> new DocumentStatusResponse(
+                        it.id(),
+                        it.filename(),
+                        it.status(),
+                        it.chunkCount(),
+                        it.errorMessage(),
+                        it.updatedAt()));
+    }
+}

--- a/server/src/main/java/ai/jarvis/rag/DocumentStatusResponse.java
+++ b/server/src/main/java/ai/jarvis/rag/DocumentStatusResponse.java
@@ -9,5 +9,5 @@ public record DocumentStatusResponse(
         DocumentStatus status,
         int chunkCount,
         String errorMessage,
-        Instant completedAt) {
+        Instant updatedAt) {
 }

--- a/server/src/main/java/ai/jarvis/rag/DocumentStatusResponse.java
+++ b/server/src/main/java/ai/jarvis/rag/DocumentStatusResponse.java
@@ -1,0 +1,13 @@
+package ai.jarvis.rag;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record DocumentStatusResponse(
+        UUID id,
+        String filename,
+        DocumentStatus status,
+        int chunkCount,
+        String errorMessage,
+        Instant completedAt) {
+}

--- a/server/src/test/java/ai/jarvis/rag/DocumentControllerTest.java
+++ b/server/src/test/java/ai/jarvis/rag/DocumentControllerTest.java
@@ -1,13 +1,16 @@
 package ai.jarvis.rag;
 
 import static org.mockito.Mockito.when;
+import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.TOKEN;
 
 import java.time.Instant;
 import java.util.UUID;
 
-import ai.jarvis.config.TestSecurityConfig;
+import ai.jarvis.config.SecurityConfig;
 import ai.jarvis.config.WithMockJarvisUser;
+import ai.jarvis.security.jwt.JwtAuthenticationFilter;
 import ai.jarvis.security.jwt.JwtService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -23,8 +27,8 @@ import reactor.core.publisher.Mono;
 
 @WebFluxTest(controllers = {DocumentController.class})
 @ExtendWith(MockitoExtension.class)
-@Import(TestSecurityConfig.class)
-@WithMockJarvisUser(principal = DocumentControllerTest.USER_ID_RAW)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+@DisplayName("DocumentController Tests")
 class DocumentControllerTest {
 
     public static final String USER_ID_RAW = "3bb93254-6ce0-4cd3-91b3-a292a46e8fe9";
@@ -39,7 +43,17 @@ class DocumentControllerTest {
     @MockitoBean
     private JwtService jwtService;
 
+    @BeforeEach
+    void setUp() {
+        when(jwtService.validateToken(TOKEN)).thenReturn(true);
+        when(jwtService.extractTokenType(TOKEN)).thenReturn("access");
+        when(jwtService.extractUserId(TOKEN)).thenReturn(USER_ID_RAW);
+        when(jwtService.extractUsername(TOKEN)).thenReturn("test-user");
+        when(jwtService.extractRole(TOKEN)).thenReturn("USER");
+    }
+
     @Test
+    @WithMockJarvisUser(principal = DocumentControllerTest.USER_ID_RAW)
     @DisplayName("Test GET /api/v1/documents/{documentId}/status - Should return document status")
     void testGetDocumentStatus_ShouldReturnStatus() {
         UUID documentId = UUID.fromString("5eff485b-1ca6-4d4f-b94c-c30c010de82b");
@@ -57,6 +71,7 @@ class DocumentControllerTest {
         webTestClient
                 .get()
                 .uri("/api/v1/documents/{documentId}/status", documentId)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + TOKEN)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
@@ -65,6 +80,7 @@ class DocumentControllerTest {
     }
 
     @Test
+    @WithMockJarvisUser(principal = DocumentControllerTest.USER_ID_RAW)
     @DisplayName("Test GET /api/v1/documents/{documentId}/status - Should return bad request when invalid document id provided")
     void testGetDocumentStatus_ShouldReturnBadRequestWhenInvalidIdProvided() {
         String invalidDocumentId = "invalid id";
@@ -72,11 +88,13 @@ class DocumentControllerTest {
         webTestClient
                 .get()
                 .uri("/api/v1/documents/{documentId}/status", invalidDocumentId)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + TOKEN)
                 .exchange()
                 .expectStatus().isBadRequest();
     }
 
     @Test
+    @WithMockJarvisUser(principal = DocumentControllerTest.USER_ID_RAW)
     @DisplayName("Test GET /api/v1/documents/{documentId}/status - Should return not found when document was not found by id")
     void testGetDocumentStatus_ShouldReturnNotFoundWhenDocumentNotFound() {
         UUID documentId = UUID.fromString("5eff485b-1ca6-4d4f-b94c-c30c010de82b");
@@ -87,8 +105,19 @@ class DocumentControllerTest {
         webTestClient
                 .get()
                 .uri("/api/v1/documents/{documentId}/status", documentId)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + TOKEN)
                 .exchange()
                 .expectStatus().isNotFound();
     }
 
+    @Test
+    @DisplayName("GET /{id}/status - returns 401 without JWT token")
+    void testGetDocumentStatus_ShouldReturnUnauthorizedWithoutToken() {
+        webTestClient
+                .get()
+                .uri("/api/v1/documents/{documentId}/status",
+                        UUID.randomUUID())
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
 }

--- a/server/src/test/java/ai/jarvis/rag/DocumentControllerTest.java
+++ b/server/src/test/java/ai/jarvis/rag/DocumentControllerTest.java
@@ -1,12 +1,12 @@
 package ai.jarvis.rag;
 
 import static org.mockito.Mockito.when;
-import static org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames.TOKEN;
 
 import java.time.Instant;
 import java.util.UUID;
 
 import ai.jarvis.config.SecurityConfig;
+import ai.jarvis.config.TestSecurityConfig;
 import ai.jarvis.config.WithMockJarvisUser;
 import ai.jarvis.security.jwt.JwtAuthenticationFilter;
 import ai.jarvis.security.jwt.JwtService;
@@ -27,12 +27,14 @@ import reactor.core.publisher.Mono;
 
 @WebFluxTest(controllers = {DocumentController.class})
 @ExtendWith(MockitoExtension.class)
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+@Import(TestSecurityConfig.class)
 @DisplayName("DocumentController Tests")
 class DocumentControllerTest {
 
     public static final String USER_ID_RAW = "3bb93254-6ce0-4cd3-91b3-a292a46e8fe9";
     public static final UUID USER_ID = UUID.fromString(USER_ID_RAW);
+
+    private static final String TOKEN = "test-bearer-token";
 
     @Autowired
     private WebTestClient webTestClient;
@@ -53,7 +55,6 @@ class DocumentControllerTest {
     }
 
     @Test
-    @WithMockJarvisUser(principal = DocumentControllerTest.USER_ID_RAW)
     @DisplayName("Test GET /api/v1/documents/{documentId}/status - Should return document status")
     void testGetDocumentStatus_ShouldReturnStatus() {
         UUID documentId = UUID.fromString("5eff485b-1ca6-4d4f-b94c-c30c010de82b");
@@ -80,7 +81,6 @@ class DocumentControllerTest {
     }
 
     @Test
-    @WithMockJarvisUser(principal = DocumentControllerTest.USER_ID_RAW)
     @DisplayName("Test GET /api/v1/documents/{documentId}/status - Should return bad request when invalid document id provided")
     void testGetDocumentStatus_ShouldReturnBadRequestWhenInvalidIdProvided() {
         String invalidDocumentId = "invalid id";
@@ -94,14 +94,15 @@ class DocumentControllerTest {
     }
 
     @Test
-    @WithMockJarvisUser(principal = DocumentControllerTest.USER_ID_RAW)
     @DisplayName("Test GET /api/v1/documents/{documentId}/status - Should return not found when document was not found by id")
     void testGetDocumentStatus_ShouldReturnNotFoundWhenDocumentNotFound() {
         UUID documentId = UUID.fromString("5eff485b-1ca6-4d4f-b94c-c30c010de82b");
-        ResponseStatusException documentNotFoundException = new ResponseStatusException(HttpStatus.NOT_FOUND, "Document not found");
 
-        when(documentService.getDocumentByIdAndUserId(documentId, USER_ID)).thenReturn(Mono.error(documentNotFoundException));
-
+        when(documentService.getDocumentByIdAndUserId(documentId, USER_ID))
+                .thenReturn(Mono.error(
+                        new ResponseStatusException(
+                                HttpStatus.NOT_FOUND,
+                                "Document not found")));
         webTestClient
                 .get()
                 .uri("/api/v1/documents/{documentId}/status", documentId)

--- a/server/src/test/java/ai/jarvis/rag/DocumentControllerTest.java
+++ b/server/src/test/java/ai/jarvis/rag/DocumentControllerTest.java
@@ -1,0 +1,94 @@
+package ai.jarvis.rag;
+
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import ai.jarvis.config.TestSecurityConfig;
+import ai.jarvis.config.WithMockJarvisUser;
+import ai.jarvis.security.jwt.JwtService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+
+@WebFluxTest(controllers = {DocumentController.class})
+@ExtendWith(MockitoExtension.class)
+@Import(TestSecurityConfig.class)
+@WithMockJarvisUser(principal = DocumentControllerTest.USER_ID_RAW)
+class DocumentControllerTest {
+
+    public static final String USER_ID_RAW = "3bb93254-6ce0-4cd3-91b3-a292a46e8fe9";
+    public static final UUID USER_ID = UUID.fromString(USER_ID_RAW);
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockitoBean
+    private DocumentService documentService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Test
+    @DisplayName("Test GET /api/v1/documents/{documentId}/status - Should return document status")
+    void testGetDocumentStatus_ShouldReturnStatus() {
+        UUID documentId = UUID.fromString("5eff485b-1ca6-4d4f-b94c-c30c010de82b");
+        DocumentStatusResponse statusResponse = new DocumentStatusResponse(
+                documentId,
+                "test-file",
+                DocumentStatus.READY,
+                300,
+                null,
+                Instant.now()
+        );
+
+        when(documentService.getDocumentByIdAndUserId(documentId, USER_ID)).thenReturn(Mono.just(statusResponse));
+
+        webTestClient
+                .get()
+                .uri("/api/v1/documents/{documentId}/status", documentId)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.data.id").isEqualTo(statusResponse.id().toString())
+                .jsonPath("$.data.status").isEqualTo(statusResponse.status().toString());
+    }
+
+    @Test
+    @DisplayName("Test GET /api/v1/documents/{documentId}/status - Should return bad request when invalid document id provided")
+    void testGetDocumentStatus_ShouldReturnBadRequestWhenInvalidIdProvided() {
+        String invalidDocumentId = "invalid id";
+
+        webTestClient
+                .get()
+                .uri("/api/v1/documents/{documentId}/status", invalidDocumentId)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    @DisplayName("Test GET /api/v1/documents/{documentId}/status - Should return not found when document was not found by id")
+    void testGetDocumentStatus_ShouldReturnNotFoundWhenDocumentNotFound() {
+        UUID documentId = UUID.fromString("5eff485b-1ca6-4d4f-b94c-c30c010de82b");
+        ResponseStatusException documentNotFoundException = new ResponseStatusException(HttpStatus.NOT_FOUND, "Document not found");
+
+        when(documentService.getDocumentByIdAndUserId(documentId, USER_ID)).thenReturn(Mono.error(documentNotFoundException));
+
+        webTestClient
+                .get()
+                .uri("/api/v1/documents/{documentId}/status", documentId)
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+
+}

--- a/server/src/test/java/ai/jarvis/rag/DocumentControllerTest.java
+++ b/server/src/test/java/ai/jarvis/rag/DocumentControllerTest.java
@@ -5,10 +5,7 @@ import static org.mockito.Mockito.when;
 import java.time.Instant;
 import java.util.UUID;
 
-import ai.jarvis.config.SecurityConfig;
 import ai.jarvis.config.TestSecurityConfig;
-import ai.jarvis.config.WithMockJarvisUser;
-import ai.jarvis.security.jwt.JwtAuthenticationFilter;
 import ai.jarvis.security.jwt.JwtService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/server/src/test/java/ai/jarvis/rag/DocumentServiceTest.java
+++ b/server/src/test/java/ai/jarvis/rag/DocumentServiceTest.java
@@ -1,6 +1,5 @@
 package ai.jarvis.rag;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -63,9 +62,12 @@ class DocumentServiceTest {
 
         when(documentRepository.findByIdAndUserId(documentId, userId)).thenReturn(Mono.just(document));
 
-        Mono<DocumentStatusResponse> result = documentService.getDocumentByIdAndUserId(documentId, userId);
+        StepVerifier.create(documentService.getDocumentByIdAndUserId(documentId, userId))
+                .expectNextMatches(response ->
+                        response.filename().equals("test.txt")
+                                && response.id().equals(documentId))
+                .verifyComplete();
 
-        assertThat(result).isNotNull();
         verify(documentRepository).findByIdAndUserId(documentId, userId);
     }
 }

--- a/server/src/test/java/ai/jarvis/rag/DocumentServiceTest.java
+++ b/server/src/test/java/ai/jarvis/rag/DocumentServiceTest.java
@@ -1,0 +1,64 @@
+package ai.jarvis.rag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import reactor.core.publisher.Mono;
+
+@DisplayName("DocumentService Tests")
+@ExtendWith(MockitoExtension.class)
+class DocumentServiceTest {
+
+    @Mock
+    private DocumentRepository documentRepository;
+
+    @InjectMocks
+    private DocumentService documentService;
+
+    @Test
+    @DisplayName("getDocumentByIdAndUserId() should throw excpetion if user was not found")
+    void shouldThrowExceptionIfUserNotFound() {
+        UUID userId = UUID.randomUUID();
+        UUID documentId = UUID.randomUUID();
+
+        when(documentRepository.findByIdAndUserId(documentId, userId)).thenReturn(Mono.empty());
+
+        Assertions.assertThatThrownBy(() -> documentService.getDocumentByIdAndUserId(documentId, userId))
+                .isExactlyInstanceOf(ResponseStatusException.class);
+        verify(documentRepository).findByIdAndUserId(documentId, userId);
+    }
+
+    @Test
+    @DisplayName("getDocumentByIdAndUserId() returns document")
+    void shouldReturnDocument() {
+        UUID userId = UUID.randomUUID();
+        UUID documentId = UUID.randomUUID();
+
+        Document document = Document.create(
+                userId,
+                "test.txt",
+                DocumentFileType.TXT,
+                1024L,
+                "This is a test document"
+        );
+
+        when(documentRepository.findByIdAndUserId(documentId, userId)).thenReturn(Mono.just(document));
+
+        Mono<DocumentStatusResponse> result = documentService.getDocumentByIdAndUserId(documentId, userId);
+
+        assertThat(result).isNotNull();
+        verify(documentRepository).findByIdAndUserId(documentId, userId);
+    }
+}

--- a/server/src/test/java/ai/jarvis/rag/DocumentServiceTest.java
+++ b/server/src/test/java/ai/jarvis/rag/DocumentServiceTest.java
@@ -13,9 +13,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 @DisplayName("DocumentService Tests")
 @ExtendWith(MockitoExtension.class)
@@ -28,15 +30,20 @@ class DocumentServiceTest {
     private DocumentService documentService;
 
     @Test
-    @DisplayName("getDocumentByIdAndUserId() should throw excpetion if user was not found")
-    void shouldThrowExceptionIfUserNotFound() {
+    @DisplayName("getDocumentByIdAndUserId() should throw exception if document was not found")
+    void shouldThrowExceptionIfDocumentNotFound() {
         UUID userId = UUID.randomUUID();
         UUID documentId = UUID.randomUUID();
 
         when(documentRepository.findByIdAndUserId(documentId, userId)).thenReturn(Mono.empty());
 
-        Assertions.assertThatThrownBy(() -> documentService.getDocumentByIdAndUserId(documentId, userId))
-                .isExactlyInstanceOf(ResponseStatusException.class);
+        StepVerifier.create(documentService.getDocumentByIdAndUserId(documentId, userId))
+                .expectErrorSatisfies(ex -> Assertions.assertThat(ex)
+                        .isInstanceOf(ResponseStatusException.class)
+                        .extracting(e -> ((ResponseStatusException) e).getStatusCode())
+                        .isEqualTo(HttpStatus.NOT_FOUND))
+                .verify();
+
         verify(documentRepository).findByIdAndUserId(documentId, userId);
     }
 


### PR DESCRIPTION
## What Does This PR Do?

Related Issue: Closes #95

---

## Related Issue

Closes #[issue number]

---

## Type of Change

* [ ] 🐛 Bug fix
* [x] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [ ] 🧪 Tests
* [ ] 🔧 Maintenance / chore

---

## Testing

* [x] `./mvnw test` passes
* [ ] Tested with Ollama running locally
* [x] Tested on OS: MacOs
* [x] New tests added for this change

---

## Checklist

* [x] Code follows the project coding standards
* [x] I have reviewed my own changes
* [ ] Documentation updated (if needed)
* [x] No secrets or API keys in the code
* [ ] Conventional commit messages used
* [x] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)

[Add screenshots or terminal output here]

<img width="1918" height="498" alt="image" src="https://github.com/user-attachments/assets/b58e2031-75ea-44eb-960d-230691e8eca3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API to view the status of a document by ID, including processing state, file name, chunk count, error details, and last update time.
  * Document access is now tied to the signed-in user, improving account-level data isolation.

* **Bug Fixes**
  * Requests with invalid authentication tokens now return a clear unauthorized response.
  * Missing documents now return a not-found response instead of failing unexpectedly.

* **Tests**
  * Added coverage for successful, unauthorized, invalid-ID, and not-found document status requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->