### PR TITLE
fix(memory): use saveWithEmbedding() in MemoryExtractionService

### DIFF
--- a/server/src/main/java/ai/jarvis/memory/MemoryExtractionService.java
+++ b/server/src/main/java/ai/jarvis/memory/MemoryExtractionService.java
@@ -55,11 +55,9 @@ public class MemoryExtractionService {
             Output: []
             """;
 
-    // Fix 2: timeout constant — configurable and visible
     private static final Duration EXTRACTION_TIMEOUT =
             Duration.ofSeconds(15);
 
-    // Fix 3: hard cap enforced in code, not just in prompt
     private static final int MAX_MEMORIES_PER_MESSAGE = 3;
 
     public Mono<Void> extractAndSave(
@@ -67,8 +65,6 @@ public class MemoryExtractionService {
             UUID sessionId,
             String userMessage) {
 
-        // Fix 1: guard null identifiers FIRST
-        // Prevents wasted Ollama calls and DB errors
         if (userId == null || sessionId == null) {
             log.debug(
                     "Skipping extraction: null "
@@ -76,7 +72,7 @@ public class MemoryExtractionService {
             return Mono.empty();
         }
 
-        // Short messages have nothing to extract
+        // Short messages have nothing to extract.
         if (userMessage == null
                 || userMessage.trim().length() < 10) {
             return Mono.empty();
@@ -85,15 +81,13 @@ public class MemoryExtractionService {
         return Mono.fromCallable(() ->
                         callExtractionModel(userMessage))
                 .subscribeOn(Schedulers.boundedElastic())
-                // Fix 2: timeout prevents thread starvation
-                // if Ollama is slow or unresponsive
                 .timeout(EXTRACTION_TIMEOUT)
                 .flatMap(json ->
                         parseAndSaveAll(
                                 json, userId, sessionId))
                 .onErrorResume(error -> {
-                    // Handles ALL errors including TimeoutException
-                    // Extraction failure NEVER affects chat
+                    // Handles ALL errors including TimeoutException.
+                    // Extraction failure NEVER affects chat.
                     log.debug(
                             "Memory extraction skipped "
                                     + "for user={}: {}",
@@ -157,14 +151,9 @@ public class MemoryExtractionService {
 
         return reactor.core.publisher.Flux
                 .fromIterable(extracted)
-                // Fix 3: hard cap regardless of AI output
-                // Prompt says max 3, but AI is not 100% reliable
-                // .take(3) GUARANTEES max 3 saves
                 .take(MAX_MEMORIES_PER_MESSAGE)
-                // concatMap = sequential saves
-                // Prevents race condition in duplicate check
                 .concatMap(m ->
-                        memoryService.save(
+                        memoryService.saveWithEmbedding(
                                 userId,
                                 m.type(),
                                 m.content(),

--- a/server/src/test/java/ai/jarvis/memory/MemoryExtractionServiceAdditionalTest.java
+++ b/server/src/test/java/ai/jarvis/memory/MemoryExtractionServiceAdditionalTest.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
@@ -64,97 +63,112 @@ class MemoryExtractionServiceAdditionalTest {
         when(requestSpec.call())
                 .thenReturn(callResponseSpec);
     }
+
     @Test
-@DisplayName("valid JSON extraction saves memories")
-void shouldSaveExtractedMemories() {
+    @DisplayName("valid JSON extraction saves memories with embedding")
+    void shouldSaveExtractedMemories() {
 
-    when(callResponseSpec.content())
-            .thenReturn("""
-                    [
-                      {
-                        "type": "PREFERENCE",
-                        "content": "User likes Java"
-                      }
-                    ]
-                    """);
+        when(callResponseSpec.content())
+                .thenReturn("""
+                        [
+                          {
+                            "type": "PREFERENCE",
+                            "content": "User likes Java"
+                          }
+                        ]
+                        """);
 
-    when(memoryService.save(
-            any(), any(), any(), any()))
-            .thenReturn(Mono.empty());
+        // saveWithEmbedding() is called because extracted memories
+        // must receive pgvector embeddings to be discoverable
+        // via semantic search. save() only stores text with no embedding.
+        when(memoryService.saveWithEmbedding(
+                any(), any(), any(), any()))
+                .thenReturn(Mono.empty());
 
-    StepVerifier.create(
-            service.extractAndSave(
-                    userId,
-                    sessionId,
-                    "I really enjoy coding in Java"))
-            .verifyComplete();
+        StepVerifier.create(
+                        service.extractAndSave(
+                                userId,
+                                sessionId,
+                                "I really enjoy coding in Java"))
+                .verifyComplete();
 
-    verify(memoryService)
-            .save(any(), any(), any(), any());
-}
-@Test
-@DisplayName("empty JSON array saves nothing")
-void shouldSaveNothingForEmptyArray() {
+        verify(memoryService)
+                .saveWithEmbedding(any(), any(), any(), any());
+    }
 
-    when(callResponseSpec.content())
-            .thenReturn("[]");
+    @Test
+    @DisplayName("empty JSON array saves nothing")
+    void shouldSaveNothingForEmptyArray() {
 
-    StepVerifier.create(
-            service.extractAndSave(
-                    userId,
-                    sessionId,
-                    "I really enjoy coding in Java"))
-            .verifyComplete();
+        when(callResponseSpec.content())
+                .thenReturn("[]");
 
-    verify(memoryService, never())
-            .save(any(), any(), any(), any());
-}
+        StepVerifier.create(
+                        service.extractAndSave(
+                                userId,
+                                sessionId,
+                                "I really enjoy coding in Java"))
+                .verifyComplete();
 
-@Test
-@DisplayName("malformed JSON is handled gracefully")
-void shouldHandleMalformedJson() {
+        // Neither save() nor saveWithEmbedding() should be called
+        // when AI returns empty array
+        verify(memoryService, never())
+                .saveWithEmbedding(any(), any(), any(), any());
 
-    when(callResponseSpec.content())
-            .thenReturn("This is not JSON at all!");
+        verify(memoryService, never())
+                .save(any(), any(), any(), any());
+    }
 
-    StepVerifier.create(
-            service.extractAndSave(
-                    userId,
-                    sessionId,
-                    "I really enjoy coding in Java"))
-            .verifyComplete();
+    @Test
+    @DisplayName("malformed JSON is handled gracefully")
+    void shouldHandleMalformedJson() {
 
-    verify(memoryService, never())
-            .save(any(), any(), any(), any());
-}
+        when(callResponseSpec.content())
+                .thenReturn("This is not JSON at all!");
 
-@Test
-@DisplayName("maximum of 3 memories enforced")
-void shouldEnforceMaxThreeMemories() {
+        StepVerifier.create(
+                        service.extractAndSave(
+                                userId,
+                                sessionId,
+                                "I really enjoy coding in Java"))
+                .verifyComplete();
 
-    when(callResponseSpec.content())
-            .thenReturn("""
-                    [
-                      {"type":"PREFERENCE","content":"User likes Java"},
-                      {"type":"FACT","content":"User uses Windows"},
-                      {"type":"GOAL","content":"User builds Jarvis"},
-                      {"type":"CONTEXT","content":"User has 16GB RAM"},
-                      {"type":"EVENT","content":"User published article"}
-                    ]
-                    """);
+        // Malformed JSON must never reach the service layer
+        verify(memoryService, never())
+                .saveWithEmbedding(any(), any(), any(), any());
 
-    when(memoryService.save(
-            any(), any(), any(), any()))
-            .thenReturn(Mono.empty());
+        verify(memoryService, never())
+                .save(any(), any(), any(), any());
+    }
 
-    StepVerifier.create(
-            service.extractAndSave(
-                    userId,
-                    sessionId,
-                    "I really enjoy coding in Java"))
-            .verifyComplete();
+    @Test
+    @DisplayName("maximum of 3 memories enforced")
+    void shouldEnforceMaxThreeMemories() {
 
-    verify(memoryService, times(3))
-            .save(any(), any(), any(), any());
-}
+        when(callResponseSpec.content())
+                .thenReturn("""
+                        [
+                          {"type":"PREFERENCE","content":"User likes Java"},
+                          {"type":"FACT","content":"User uses Windows"},
+                          {"type":"GOAL","content":"User builds Jarvis"},
+                          {"type":"CONTEXT","content":"User has 16GB RAM"},
+                          {"type":"EVENT","content":"User published article"}
+                        ]
+                        """);
+
+
+        when(memoryService.saveWithEmbedding(
+                any(), any(), any(), any()))
+                .thenReturn(Mono.empty());
+
+        StepVerifier.create(
+                        service.extractAndSave(
+                                userId,
+                                sessionId,
+                                "I really enjoy coding in Java"))
+                .verifyComplete();
+
+        verify(memoryService, times(3))
+                .saveWithEmbedding(any(), any(), any(), any());
+    }
 }


### PR DESCRIPTION
Auto-extracted memories were stored via save() which persists the text but skips embedding generation. This made every memory extracted from a conversation invisible to semantic search — only appearing in the importance-based fallback. Switched to saveWithEmbedding() so extracted memories receive pgvector embeddings and are discoverable via cosine similarity search.

## What Does This PR Do?

[Brief description of your changes]

---

## Related Issue

Closes #[issue number]

---

## Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [ ] 🧪 Tests
* [ ] 🔧 Maintenance / chore

---

## Testing

* [ ] `./mvnw test` passes
* [ ] Tested with Ollama running locally
* [ ] Tested on OS: _______________
* [ ] New tests added for this change

---

## Checklist

* [ ] Code follows the project coding standards
* [ ] I have reviewed my own changes
* [ ] Documentation updated (if needed)
* [ ] No secrets or API keys in the code
* [ ] Conventional commit messages used
* [ ] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)

[Add screenshots or terminal output here]
