### PR TITLE
fix(agents): explicitly null finalAnswer and errorMessage in withFail…

### DIFF
--- a/server/src/main/java/ai/jarvis/agents/Agent.java
+++ b/server/src/main/java/ai/jarvis/agents/Agent.java
@@ -13,14 +13,23 @@ import java.util.UUID;
  * IMMUTABLE RECORD:
  * Use Agent.create() to make a new agent.
  * Use withXxx() to create updated copies.
- * Never mutate directly — same pattern as Memory.java.
+ * Never mutate directly.
  *
  * LIFECYCLE TRANSITIONS:
- * create() → PENDING
- * withRunning() → RUNNING
- * withCompleted() → COMPLETED + stores finalAnswer
- * withFailed() → FAILED + stores errorMessage
- * withCancelled() → CANCELLED
+ * create()        → PENDING
+ * withRunning()   → RUNNING   (requires PENDING)
+ * withCompleted() → COMPLETED (requires RUNNING)
+ * withFailed()    → FAILED    (requires RUNNING)
+ * withCancelled() → CANCELLED (any non-terminal)
+ *
+ * DB CONSTRAINTS (V15 migration):
+ * final_answer IS NULL OR status = 'COMPLETED'
+ * error_message IS NULL OR status = 'FAILED'
+ *
+ * withFailed() and withCancelled() must explicitly
+ * set finalAnswer = null to satisfy the DB constraint.
+ * Carrying through a non-null finalAnswer from a prior
+ * state would cause the UPDATE to be rejected.
  */
 @Table("agents")
 public record Agent(
@@ -82,7 +91,7 @@ public record Agent(
     // ── State Guards ──────────────────────────────
 
     /**
-     * Check if the agent is in the terminal state.
+     * Check if the agent is in a terminal state.
      * Terminal agents cannot transition to any other state.
      */
     private boolean isTerminal() {
@@ -129,8 +138,8 @@ public record Agent(
 
     /**
      * RUNNING → COMPLETED.
-     * requireStatus(RUNNING) prevents
-     * jumping to COMPLETED from PENDING.
+     * requireStatus(RUNNING) prevents jumping
+     * to COMPLETED from PENDING.
      */
     public Agent withCompleted(
             String answer,
@@ -141,23 +150,29 @@ public record Agent(
                 id, userId, sessionId, goal,
                 AgentStatus.COMPLETED,
                 answer, totalSteps,
-                null,           // no error
+                null,
                 totalDurationMs,
                 createdAt, Instant.now(),
-                Instant.now()); // completedAt   = now
+                Instant.now());
     }
 
     /**
      * RUNNING → FAILED.
-     * requireStatus(RUNNING) prevents
-     * failing a PENDING or already terminal agent.
+     * requireStatus(RUNNING) prevents failing
+     * a PENDING or already terminal agent.
+     *
+     * finalAnswer explicitly set to null.
+     * DB constraint: final_answer IS NULL OR status = 'COMPLETED'.
+     * Carrying through a non-null finalAnswer from a prior
+     * state would cause the DB UPDATE to be rejected.
      */
     public Agent withFailed(String error) {
         requireStatus(AgentStatus.RUNNING);
         return new Agent(
                 id, userId, sessionId, goal,
                 AgentStatus.FAILED,
-                finalAnswer, stepCount,
+                null,
+                stepCount,
                 error, durationMs,
                 createdAt, Instant.now(),
                 Instant.now());
@@ -165,8 +180,16 @@ public record Agent(
 
     /**
      * Any non-terminal → CANCELLED.
-     * isTerminal() check prevents
-     * cancelling an already completed agent.
+     * isTerminal() check prevents cancelling
+     * an already completed agent.
+     *
+     * finalAnswer explicitly set to null.
+     * DB constraint: final_answer IS NULL OR status = 'COMPLETED'.
+     * A CANCELLED agent never has a final answer.
+     *
+     * errorMessage explicitly set to null.
+     * DB constraint: error_message IS NULL OR status = 'FAILED'.
+     * A CANCELLED agent has no error message.
      */
     public Agent withCancelled() {
         if (isTerminal()) {
@@ -177,8 +200,10 @@ public record Agent(
         return new Agent(
                 id, userId, sessionId, goal,
                 AgentStatus.CANCELLED,
-                finalAnswer, stepCount,
-                null, durationMs,
+                null,
+                stepCount,
+                null,
+                durationMs,
                 createdAt, Instant.now(),
                 Instant.now());
     }

--- a/server/src/test/java/ai/jarvis/agents/AgentTest.java
+++ b/server/src/test/java/ai/jarvis/agents/AgentTest.java
@@ -74,7 +74,6 @@ class AgentTest {
                         UUID.randomUUID(), null, "Test")
                 .withRunning();
 
-        // Cannot go RUNNING → RUNNING
         assertThatThrownBy(running::withRunning)
                 .isInstanceOf(
                         IllegalStateException.class)
@@ -109,7 +108,6 @@ class AgentTest {
         Agent agent = Agent.create(
                 UUID.randomUUID(), null, "Test");
 
-        // Cannot go PENDING → COMPLETED directly
         assertThatThrownBy(() ->
                 agent.withCompleted("answer", 1, 100))
                 .isInstanceOf(
@@ -133,6 +131,20 @@ class AgentTest {
         assertThat(failed.errorMessage())
                 .isEqualTo("Tool timed out");
         assertThat(failed.completedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("withFailed() sets finalAnswer to null — satisfies DB constraint")
+    void shouldSetFinalAnswerNullOnFailed() {
+        Agent agent = Agent.create(
+                        UUID.randomUUID(), null, "Test")
+                .withRunning();
+
+        Agent failed = agent.withFailed("Some error");
+
+        assertThat(failed.finalAnswer()).isNull();
+        assertThat(failed.status())
+                .isEqualTo(AgentStatus.FAILED);
     }
 
     @Test
@@ -163,6 +175,35 @@ class AgentTest {
     }
 
     @Test
+    @DisplayName("withCancelled() sets finalAnswer to null — satisfies DB constraint")
+    void shouldSetFinalAnswerNullOnCancelled() {
+        // DB constraint: final_answer IS NULL OR status = 'COMPLETED'
+        // withCancelled() must always produce null finalAnswer.
+        Agent running = Agent.create(
+                        UUID.randomUUID(), null, "Test")
+                .withRunning();
+
+        Agent cancelled = running.withCancelled();
+
+        assertThat(cancelled.finalAnswer()).isNull();
+        assertThat(cancelled.errorMessage()).isNull();
+    }
+
+    @Test
+    @DisplayName("withCancelled() sets errorMessage to null — satisfies DB constraint")
+    void shouldSetErrorMessageNullOnCancelled() {
+        // DB constraint: error_message IS NULL OR status = 'FAILED'
+        // withCancelled() must always produce null errorMessage.
+        Agent running = Agent.create(
+                        UUID.randomUUID(), null, "Test")
+                .withRunning();
+
+        Agent cancelled = running.withCancelled();
+
+        assertThat(cancelled.errorMessage()).isNull();
+    }
+
+    @Test
     @DisplayName("withCancelled() throws if already terminal")
     void shouldThrowWhenCancellingTerminal() {
         Agent completed = Agent.create(
@@ -189,7 +230,7 @@ class AgentTest {
         Agent step2 = step1.withIncrementedStepCount();
         assertThat(step2.stepCount()).isEqualTo(2);
 
-        // Originals unchanged
+        // Originals unchanged — immutable record
         assertThat(agent.stepCount()).isEqualTo(0);
     }
 
@@ -280,7 +321,6 @@ class AgentTest {
                 UUID.randomUUID(),
                 2, "tool", "result");
 
-        // OBSERVE is already DONE — cannot go RUNNING
         assertThatThrownBy(observe::withRunning)
                 .isInstanceOf(
                         IllegalStateException.class)


### PR DESCRIPTION
…ed() and withCancelled()

V15 DB constraints require:
  final_answer IS NULL OR status = 'COMPLETED'
  error_message IS NULL OR status = 'FAILED'

withFailed() and withCancelled() were carrying through the existing finalAnswer value which could violate the constraint if non-null. Both transitions now explicitly set finalAnswer = null and errorMessage = null to satisfy the DB constraints at all times.

## What Does This PR Do?

[Brief description of your changes]

---

## Related Issue

Closes #[issue number]

---

## Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [ ] 🧪 Tests
* [ ] 🔧 Maintenance / chore

---

## Testing

* [ ] `./mvnw test` passes
* [ ] Tested with Ollama running locally
* [ ] Tested on OS: _______________
* [ ] New tests added for this change

---

## Checklist

* [ ] Code follows the project coding standards
* [ ] I have reviewed my own changes
* [ ] Documentation updated (if needed)
* [ ] No secrets or API keys in the code
* [ ] Conventional commit messages used
* [ ] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)

[Add screenshots or terminal output here]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured failed or cancelled agent runs no longer retain a previous final answer.
  * Preserved consistent terminal-state data, including clearing error details when an agent is cancelled.

* **Tests**
  * Added coverage validating that failure and cancellation transitions correctly clear fields according to their final status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->