### PR TITLE
fix(user): remove empty UserResponse class from ai.jarvis.user

### DIFF
--- a/server/src/main/java/ai/jarvis/user/UserResponse.java
+++ b/server/src/main/java/ai/jarvis/user/UserResponse.java
@@ -1,4 +1,0 @@
-package ai.jarvis.user;
-
-public class UserResponse {
-}


### PR DESCRIPTION
The empty UserResponse class in ai.jarvis.user served no purpose and created a naming collision with the real UserResponse record in ai.jarvis.security.auth.response which is used by UserMapper and AuthController.

## What Does This PR Do?

[Brief description of your changes]

---

## Related Issue

Closes #[issue number]

---

## Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [ ] 🧪 Tests
* [ ] 🔧 Maintenance / chore

---

## Testing

* [ ] `./mvnw test` passes
* [ ] Tested with Ollama running locally
* [ ] Tested on OS: _______________
* [ ] New tests added for this change

---

## Checklist

* [ ] Code follows the project coding standards
* [ ] I have reviewed my own changes
* [ ] Documentation updated (if needed)
* [ ] No secrets or API keys in the code
* [ ] Conventional commit messages used
* [ ] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)

[Add screenshots or terminal output here]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an obsolete user response component.
  * No user-facing functionality was added or changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->