### PR TITLE
fix(config): correct Gemini model name to gemini-2.0-flash

### DIFF
--- a/server/src/main/resources/db/migration/V17__update_gemini_model_name.sql
+++ b/server/src/main/resources/db/migration/V17__update_gemini_model_name.sql
@@ -1,0 +1,21 @@
+-- ═══════════════════════════════════════════════════
+-- V17: Update Gemini model name in ai_providers
+--
+-- V8 seeded gemini-1.5-flash as the Gemini fallback
+-- provider. gemini-2.0-flash is the current stable
+-- free-tier model as of 2026.
+--
+-- gemini-3.5-flash in application.yml was also wrong
+-- as this model does not exist in the Google AI API.
+-- application.yml has been corrected to gemini-2.0-flash.
+--
+-- Reference:
+-- https://ai.google.dev/gemini-api/docs/models/gemini
+-- ═══════════════════════════════════════════════════
+
+UPDATE ai_providers
+SET model_name   = 'gemini-2.0-flash',
+    display_name = 'Gemini 2.0 Flash (Cloud — Fallback)',
+    updated_at   = NOW()
+WHERE name = 'gemini-flash'
+  AND provider_type = 'GEMINI';


### PR DESCRIPTION
Three different model names existed across the codebase:
- application.yml had gemini-3.5-flash (does not exist)
- .env.example had gemini-2.0-flash (correct)
- V8 seed data had gemini-1.5-flash (outdated)

Fixed application.yml to use gemini-2.0-flash.
Added V17 migration to update the ai_providers seed record to match the canonical model name.

Reference: https://ai.google.dev/gemini-api/docs/models/gemini

## What Does This PR Do?

[Brief description of your changes]

---

## Related Issue

Closes #[issue number]

---

## Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [ ] 🧪 Tests
* [ ] 🔧 Maintenance / chore

---

## Testing

* [ ] `./mvnw test` passes
* [ ] Tested with Ollama running locally
* [ ] Tested on OS: _______________
* [ ] New tests added for this change

---

## Checklist

* [ ] Code follows the project coding standards
* [ ] I have reviewed my own changes
* [ ] Documentation updated (if needed)
* [ ] No secrets or API keys in the code
* [ ] Conventional commit messages used
* [ ] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)

[Add screenshots or terminal output here]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the Gemini integration to use the Gemini 2.0 Flash model.
  * Refreshed the provider label to clearly identify the cloud fallback configuration.
  * Existing Gemini provider settings are automatically updated during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->