### PR TITLE
feat: add examples command

### DIFF
--- a/server/src/main/java/ai/jarvis/cli/SystemCommands.java
+++ b/server/src/main/java/ai/jarvis/cli/SystemCommands.java
@@ -204,6 +204,12 @@ public class SystemCommands {
                   switch-session -n 2      Switch to session #2
                   new-session              Start fresh session
 
+                MEMORY:
+                  memory list              List all long-term memories
+                  memory add               Add a memory manually
+                  memory delete --number 3 Delete memory by number
+                  memory clear             Clear all memories
+
                 SYSTEM:
                   status                   Check all services
                   doctor                   Full health diagnostics

--- a/server/src/main/java/ai/jarvis/cli/SystemCommands.java
+++ b/server/src/main/java/ai/jarvis/cli/SystemCommands.java
@@ -187,6 +187,31 @@ public class SystemCommands {
                 + "Your AI. Your Data. Your Machine.\n";
     }
 
+    @Command(
+            name = "examples",
+            description = "Show common command usage examples"
+    )
+    public String examples() {
+        return """
+
+                QUICK START:
+                  login                    Sign in to Jarvis
+                  chat                     Start chatting with AI
+                  ask -m "question"        Quick single question
+
+                SESSION MANAGEMENT:
+                  session                  List all conversations
+                  switch-session -n 2      Switch to session #2
+                  new-session              Start fresh session
+
+                SYSTEM:
+                  status                   Check all services
+                  doctor                   Full health diagnostics
+                  jarvis-version           Version information
+                  about                    About Jarvis
+                """;
+    }
+
     private String capitalize(String s) {
         if (s == null || s.isEmpty()) return s;
         return Character.toUpperCase(s.charAt(0))

--- a/server/src/test/java/ai/jarvis/cli/SystemCommandsTest.java
+++ b/server/src/test/java/ai/jarvis/cli/SystemCommandsTest.java
@@ -25,6 +25,7 @@ class SystemCommandsTest {
 
         String result = commands.examples();
 
+        assertThat(result).isNotBlank();
         assertThat(result).contains("QUICK START");
         assertThat(result).contains("SESSION MANAGEMENT");
         assertThat(result).contains("MEMORY");

--- a/server/src/test/java/ai/jarvis/cli/SystemCommandsTest.java
+++ b/server/src/test/java/ai/jarvis/cli/SystemCommandsTest.java
@@ -1,0 +1,33 @@
+package ai.jarvis.cli;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SystemCommands Unit Tests")
+class SystemCommandsTest {
+
+    @Mock
+    private CliStateManager state;
+
+    @Mock
+    private CliHttpClient http;
+
+    @Test
+    @DisplayName("examples() returns non-blank output with key sections")
+    void shouldReturnExamplesOutput() {
+        SystemCommands commands = new SystemCommands(state, http);
+
+        String result = commands.examples();
+
+        assertThat(result).contains("QUICK START");
+        assertThat(result).contains("SESSION MANAGEMENT");
+        assertThat(result).contains("MEMORY");
+        assertThat(result).contains("SYSTEM");
+    }
+}


### PR DESCRIPTION
## What Does This PR Do?

Adds an `examples` command to the CLI that prints usage examples for the
most common commands, grouped by Quick Start / Session Management / System.
The existing `help` output lists command names but shows no example
invocations, so flags like `ask -m` and `switch-session -n` weren't
discoverable without reading the source.

All names and flags in the output were checked against the actual
`@Command` / `@Option` declarations in `AuthCommands`, `ChatCommands`,
`SessionCommands`, and `SystemCommands`.

---

## Related Issue

Closes #4 

---

## Type of Change

* [ ] 🐛 Bug fix
* [x] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [ ] 🧪 Tests
* [ ] 🔧 Maintenance / chore

---

## Testing

* [x] `./mvnw test` passes
* [ x] Tested with Ollama running locally
* [x] Tested on OS: _______________
* [ ] New tests added for this change

---

## Checklist

* [x] Code follows the project coding standards
* [x] I have reviewed my own changes
* [ ] Documentation updated (if needed)
* [ ] No secrets or API keys in the code
* [x] Conventional commit messages used
* [x] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)

[Add screenshots or terminal output here]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `examples` command that displays formatted usage examples for common tasks, including quick start, session management, memory commands, and system status/diagnostics, plus version and about details.
* **Tests**
  * Added a new test to verify the `examples` output is non-blank and includes the expected section headings: “QUICK START”, “SESSION MANAGEMENT”, “MEMORY”, and “SYSTEM”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->