### PR TITLE
test: add voice API coverage

### DIFF
--- a/server/src/main/java/ai/jarvis/voice/WhisperTranscriptionService.java
+++ b/server/src/main/java/ai/jarvis/voice/WhisperTranscriptionService.java
@@ -32,7 +32,6 @@ import java.time.Duration;
  * <p>
  * 1. Added timeouts: 30s transcription, 5s health check
  * 2. Local mode works without API key
- * isLocalMode=true when URL contains localhost
  * 3. Separate code paths for local vs cloud
  * No incompatible WebClient type casting
  */

--- a/server/src/main/java/ai/jarvis/voice/WhisperTranscriptionService.java
+++ b/server/src/main/java/ai/jarvis/voice/WhisperTranscriptionService.java
@@ -30,7 +30,6 @@ import java.time.Duration;
  * URL: http://localhost:8178
  * Setup: github.com/ggerganov/whisper.cpp
  * <p>
- * <p>
  * 1. Added timeouts: 30s transcription, 5s health check
  * 2. Local mode works without API key
  * isLocalMode=true when URL contains localhost

--- a/server/src/main/java/ai/jarvis/voice/WhisperTranscriptionService.java
+++ b/server/src/main/java/ai/jarvis/voice/WhisperTranscriptionService.java
@@ -16,26 +16,26 @@ import java.time.Duration;
 
 /**
  * Transcribes audio to text using Whisper.
- *
+ * <p>
  * Ollama does NOT support Whisper natively.
  * Use one of two modes:
- *
+ * <p>
  * MODE 1 — Groq API (cloud, free tier):
- *   Set GROQ_API_KEY in .env
- *   Free: 6000 requests/day
- *   URL: api.groq.com/openai/v1
- *
+ * Set GROQ_API_KEY in .env
+ * Free: 6000 requests/day
+ * URL: api.groq.com/openai/v1
+ * <p>
  * MODE 2 — Local whisper.cpp server:
- *   No API key required
- *   URL: http://localhost:8178
- *   Setup: github.com/ggerganov/whisper.cpp
- *
- *
+ * No API key required
+ * URL: http://localhost:8178
+ * Setup: github.com/ggerganov/whisper.cpp
+ * <p>
+ * <p>
  * 1. Added timeouts: 30s transcription, 5s health check
  * 2. Local mode works without API key
- *    isLocalMode=true when URL contains localhost
+ * isLocalMode=true when URL contains localhost
  * 3. Separate code paths for local vs cloud
- *    No incompatible WebClient type casting
+ * No incompatible WebClient type casting
  */
 @Slf4j
 @Service
@@ -162,7 +162,7 @@ public class WhisperTranscriptionService {
 
     /**
      * Check if Whisper is configured and reachable.
-     *
+     * <p>
      * Separate code paths for local vs cloud.
      * No type casting between incompatible WebClient
      * spec types (RequestHeadersSpec vs RequestBodySpec).
@@ -216,6 +216,41 @@ public class WhisperTranscriptionService {
         return isGroq ? "groq-cloud" : "remote-whisper";
     }
 
+
+    /**
+     * Builds the multipart body for a Whisper transcription request.
+     *
+     * @param audioBytes raw audio bytes
+     * @param language   optional language hint
+     * @return multipart request body
+     */
+    MultipartBodyBuilder buildMultipartBody(
+            byte[] audioBytes,
+            String language) {
+
+        MultipartBodyBuilder bodyBuilder =
+                new MultipartBodyBuilder();
+
+        bodyBuilder.part(
+                "file",
+                new ByteArrayResource(audioBytes) {
+                    @Override
+                    public String getFilename() {
+                        return "audio.wav";
+                    }
+                });
+
+        bodyBuilder.part("model", model);
+        bodyBuilder.part("response_format", "text");
+
+        if (language != null && !language.isBlank()) {
+            bodyBuilder.part("language", language);
+        }
+
+        return bodyBuilder;
+    }
+
+
     // ── Private Helpers ───────────────────────────
 
     /**
@@ -234,10 +269,10 @@ public class WhisperTranscriptionService {
     /**
      * Call Whisper via OpenAI-compatible multipart API.
      * Works with Groq API and whisper.cpp server.
-     *
+     * <p>
      * Separate code paths for local vs cloud.
      * Added TRANSCRIPTION_TIMEOUT before .block()
-     *      to prevent thread starvation.
+     * to prevent thread starvation.
      *
      * @param audioBytes raw audio bytes
      * @param language   optional language hint (nullable)
@@ -248,23 +283,7 @@ public class WhisperTranscriptionService {
             String language) {
 
         MultipartBodyBuilder bodyBuilder =
-                new MultipartBodyBuilder();
-
-        bodyBuilder.part("file",
-                new ByteArrayResource(audioBytes) {
-                    @Override
-                    public String getFilename() {
-                        return "audio.wav";
-                    }
-                });
-
-        bodyBuilder.part("model", model);
-        bodyBuilder.part("response_format", "text");
-
-        if (language != null
-                && !language.isBlank()) {
-            bodyBuilder.part("language", language);
-        }
+                buildMultipartBody(audioBytes, language);
 
         // FIX: Separate paths — no incompatible casting
         // Local whisper.cpp: no auth header
@@ -310,4 +329,6 @@ public class WhisperTranscriptionService {
 
         return response.trim();
     }
+
+
 }

--- a/server/src/test/java/ai/jarvis/voice/VoiceControllerTest.java
+++ b/server/src/test/java/ai/jarvis/voice/VoiceControllerTest.java
@@ -1,4 +1,5 @@
 package ai.jarvis.voice;
+
 import ai.jarvis.config.SecurityConfig;
 import ai.jarvis.config.TestSecurityConfig;
 import ai.jarvis.config.WithMockJarvisUser;
@@ -30,6 +31,15 @@ public class VoiceControllerTest {
 
     public static final String USER_ID_RAW = "3bb93254-6ce0-4cd3-91b3-a292a46e8fe9";
 
+
+    /**
+     * Tests authenticated Voice API requests with
+     * VoiceConversationService mocked.
+     * <p>
+     * Only methods directly invoked by the controller are stubbed.
+     * TextToSpeechService.speakAndPlay() is not stubbed because
+     * controller tests do not call the real VoiceConversationService.
+     */
     @Nested
     @WebFluxTest(controllers = {VoiceController.class})
     @Import(TestSecurityConfig.class)
@@ -45,6 +55,11 @@ public class VoiceControllerTest {
         @MockitoBean
         private JwtService jwtService;
 
+
+        /**
+         * Verifies that voice status reports ready
+         * when transcription and TTS services are available.
+         */
         @Test
         @DisplayName("Test GET /api/v1/voice/status - Should return voice ready when both services are available")
         void testVoiceStatus_ShouldReturnVoiceReady() {
@@ -65,6 +80,11 @@ public class VoiceControllerTest {
                     .jsonPath("$.data.voiceReady").isEqualTo(true);
         }
 
+
+        /**
+         * Verifies that voice status reports not ready
+         * when one of the voice services is unavailable.
+         */
         @Test
         @DisplayName("Test GET /api/v1/voice/status - Should return voice NOT ready when one service is down")
         void testVoiceStatus_ShouldReturnVoiceNotReady() {
@@ -87,6 +107,11 @@ public class VoiceControllerTest {
 
         }
 
+
+        /**
+         * Verifies that the speak endpoint returns 204
+         * when TTS completes successfully.
+         */
         @Test
         @DisplayName("Test POST /api/v1/voice/speak - Should return 204 when request is valid")
         void testVoiceSpeak_ShouldReturnNoContent() {
@@ -111,6 +136,11 @@ public class VoiceControllerTest {
 
         }
 
+
+        /**
+         * Verifies that the speak endpoint returns 503
+         * when the TTS service is unavailable.
+         */
         @Test
         @DisplayName("Test POST /api/v1/voice/speak - Should return 503 when TTS is unavailable")
         void testVoiceSpeak_ShouldReturnServiceUnavailable() {
@@ -133,6 +163,11 @@ public class VoiceControllerTest {
                     .expectStatus().isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
         }
 
+
+        /**
+         * Verifies that the speak endpoint returns 400
+         * when the request contains blank text.
+         */
         @Test
         @DisplayName("Test POST /api/v1/voice/speak - Should return 400 when text is blank")
         void testVoiceSpeak_ShouldReturnBadRequest() {
@@ -154,6 +189,11 @@ public class VoiceControllerTest {
 
         }
 
+
+        /**
+         * Verifies that the transcribe endpoint returns
+         * the transcription for valid audio.
+         */
         @Test
         @DisplayName("Test POST /api/v1/voice/transcribe - Should return transcription when audio is valid")
         void testVoiceTranscribe_ShouldReturnTranscription() {
@@ -186,6 +226,11 @@ public class VoiceControllerTest {
                     .jsonPath("$.data.transcription").isEqualTo("Hello Jarvis");
         }
 
+
+        /**
+         * Verifies that the transcribe endpoint returns 503
+         * when Whisper is unavailable.
+         */
         @Test
         @DisplayName("Test POST /api/v1/voice/transcribe - Should return 503 when whisper is unavailable")
         void testVoiceTranscribe_ShouldReturn503() {
@@ -216,6 +261,11 @@ public class VoiceControllerTest {
 
         }
 
+
+        /**
+         * Verifies that the transcribe endpoint returns 400
+         * when the uploaded audio is empty.
+         */
         @Test
         @DisplayName("Test POST /api/v1/voice/transcribe - Should return 400 when audio is empty")
         void testVoiceTranscribe_ShouldReturn400() {
@@ -251,12 +301,16 @@ public class VoiceControllerTest {
     }
 
 
+    /**
+     * Verifies that protected Voice API endpoints reject
+     * requests without JWT authentication.
+     */
+    @Nested
     @WebFluxTest(controllers = VoiceController.class)
     @Import({
             SecurityConfig.class,
             JwtAuthenticationFilter.class
     })
-    @Nested
     class UnauthorizedTests {
 
         @Autowired
@@ -268,6 +322,11 @@ public class VoiceControllerTest {
         @MockitoBean
         private VoiceConversationService voiceConversationService;
 
+
+        /**
+         * Verifies that the status endpoint returns 401
+         * when no JWT token is provided.
+         */
         @Test
         @DisplayName("Test GET /api/v1/voice/status - Should return 401 without JWT token")
         void testVoiceStatus_ShouldReturnUnauthorized() {
@@ -278,6 +337,11 @@ public class VoiceControllerTest {
                     .expectStatus().isUnauthorized();
         }
 
+
+        /**
+         * Verifies that the speak endpoint returns 401
+         * when no JWT token is provided.
+         */
         @Test
         @DisplayName("Test POST /api/v1/voice/speak - Should return 401 without JWT token")
         void testVoiceSpeak_ShouldReturnUnauthorized() {
@@ -294,6 +358,11 @@ public class VoiceControllerTest {
                     .expectStatus().isUnauthorized();
         }
 
+
+        /**
+         * Verifies that the transcribe endpoint returns 401
+         * when no JWT token is provided.
+         */
         @Test
         @DisplayName("Test POST /api/v1/voice/transcribe - Should return 401 without JWT token")
         void testVoiceTranscribe_ShouldReturnUnauthorized() {

--- a/server/src/test/java/ai/jarvis/voice/VoiceControllerTest.java
+++ b/server/src/test/java/ai/jarvis/voice/VoiceControllerTest.java
@@ -1,0 +1,326 @@
+package ai.jarvis.voice;
+import ai.jarvis.config.SecurityConfig;
+import ai.jarvis.config.TestSecurityConfig;
+import ai.jarvis.config.WithMockJarvisUser;
+import ai.jarvis.security.jwt.JwtAuthenticationFilter;
+import ai.jarvis.security.jwt.JwtService;
+import ai.jarvis.voice.exception.VoiceException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.BodyInserters;
+import reactor.core.publisher.Mono;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+
+@DisplayName("VoiceController Tests")
+public class VoiceControllerTest {
+
+    public static final String USER_ID_RAW = "3bb93254-6ce0-4cd3-91b3-a292a46e8fe9";
+
+    @Nested
+    @WebFluxTest(controllers = {VoiceController.class})
+    @Import(TestSecurityConfig.class)
+    @WithMockJarvisUser(principal = VoiceControllerTest.USER_ID_RAW)
+    class AuthenticatedTests {
+
+        @Autowired
+        private WebTestClient webTestClient;
+
+        @MockitoBean
+        private VoiceConversationService voiceConversationService;
+
+        @MockitoBean
+        private JwtService jwtService;
+
+        @Test
+        @DisplayName("Test GET /api/v1/voice/status - Should return voice ready when both services are available")
+        void testVoiceStatus_ShouldReturnVoiceReady() {
+
+            when(voiceConversationService.isTranscriptionAvailable())
+                    .thenReturn(Mono.just(true));
+            when(voiceConversationService.isTtsAvailable())
+                    .thenReturn(Mono.just(true));
+
+            this.webTestClient
+                    .get()
+                    .uri("/api/v1/voice/status")
+                    .exchange()
+                    .expectStatus().isOk()
+                    .expectBody()
+                    .jsonPath("$.data.transcriptionAvailable").isEqualTo(true)
+                    .jsonPath("$.data.ttsAvailable").isEqualTo(true)
+                    .jsonPath("$.data.voiceReady").isEqualTo(true);
+        }
+
+        @Test
+        @DisplayName("Test GET /api/v1/voice/status - Should return voice NOT ready when one service is down")
+        void testVoiceStatus_ShouldReturnVoiceNotReady() {
+
+            when(voiceConversationService.isTranscriptionAvailable())
+                    .thenReturn(Mono.just(true));
+
+            when(voiceConversationService.isTtsAvailable())
+                    .thenReturn(Mono.just(false));
+
+            this.webTestClient
+                    .get()
+                    .uri("/api/v1/voice/status")
+                    .exchange()
+                    .expectStatus().isOk()
+                    .expectBody()
+                    .jsonPath("$.data.transcriptionAvailable").isEqualTo(true)
+                    .jsonPath("$.data.ttsAvailable").isEqualTo(false)
+                    .jsonPath("$.data.voiceReady").isEqualTo(false);
+
+        }
+
+        @Test
+        @DisplayName("Test POST /api/v1/voice/speak - Should return 204 when request is valid")
+        void testVoiceSpeak_ShouldReturnNoContent() {
+
+
+            when(voiceConversationService.speakText("This is a text"))
+                    .thenReturn(Mono.empty());
+
+            this.webTestClient
+                    .post()
+                    .uri("/api/v1/voice/speak")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(
+                            """
+                                    {
+                                    "text": "This is a text"
+                                    }
+                                    """
+                    )
+                    .exchange()
+                    .expectStatus().isNoContent();
+
+        }
+
+        @Test
+        @DisplayName("Test POST /api/v1/voice/speak - Should return 503 when TTS is unavailable")
+        void testVoiceSpeak_ShouldReturnServiceUnavailable() {
+
+            when(voiceConversationService.speakText("This is a text"))
+                    .thenReturn(Mono.error(
+                            new RuntimeException("TTS service unavailable")
+                    ));
+
+            this.webTestClient
+                    .post()
+                    .uri("/api/v1/voice/speak")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue("""
+                            {
+                                "text": "This is a text"
+                            }
+                            """)
+                    .exchange()
+                    .expectStatus().isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        }
+
+        @Test
+        @DisplayName("Test POST /api/v1/voice/speak - Should return 400 when text is blank")
+        void testVoiceSpeak_ShouldReturnBadRequest() {
+
+            this.webTestClient
+                    .post()
+                    .uri("/api/v1/voice/speak")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue("""
+
+                                  {
+                             "text": ""
+                                  }
+                            """)
+                    .exchange()
+                    .expectStatus().isBadRequest();
+
+            verifyNoInteractions(voiceConversationService);
+
+        }
+
+        @Test
+        @DisplayName("Test POST /api/v1/voice/transcribe - Should return transcription when audio is valid")
+        void testVoiceTranscribe_ShouldReturnTranscription() {
+
+            byte[] audioBytes = new byte[]{1, 2, 3, 4};
+
+            when(voiceConversationService.transcribeOnly(any(byte[].class)))
+                    .thenReturn(Mono.just("Hello Jarvis"));
+
+            MultipartBodyBuilder builder = new MultipartBodyBuilder();
+
+            builder.part(
+                    "audio",
+                    new ByteArrayResource(audioBytes) {
+                        @Override
+                        public String getFilename() {
+                            return "audio.wav";
+                        }
+                    }
+            );
+
+            this.webTestClient
+                    .post()
+                    .uri("/api/v1/voice/transcribe")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(BodyInserters.fromMultipartData(builder.build()))
+                    .exchange()
+                    .expectStatus().isOk()
+                    .expectBody()
+                    .jsonPath("$.data.transcription").isEqualTo("Hello Jarvis");
+        }
+
+        @Test
+        @DisplayName("Test POST /api/v1/voice/transcribe - Should return 503 when whisper is unavailable")
+        void testVoiceTranscribe_ShouldReturn503() {
+
+            byte[] audioBytes = new byte[]{1, 2, 3, 4};
+
+            when(voiceConversationService.transcribeOnly(any(byte[].class)))
+                    .thenReturn(Mono.error(VoiceException.whisperNotAvailable()));
+
+            ByteArrayResource resource = new ByteArrayResource(audioBytes) {
+                @Override
+                public String getFilename() {
+                    return "audio.wav";
+                }
+            };
+
+            MultipartBodyBuilder builder = new MultipartBodyBuilder();
+
+            builder.part("audio", resource);
+
+            this.webTestClient
+                    .post()
+                    .uri("/api/v1/voice/transcribe")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(BodyInserters.fromMultipartData(builder.build()))
+                    .exchange()
+                    .expectStatus().isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+
+        }
+
+        @Test
+        @DisplayName("Test POST /api/v1/voice/transcribe - Should return 400 when audio is empty")
+        void testVoiceTranscribe_ShouldReturn400() {
+
+            byte[] audioBytes = new byte[0];
+
+            when(voiceConversationService.transcribeOnly(any(byte[].class)))
+                    .thenReturn(Mono.error(
+                            VoiceException.emptyAudio()));
+
+
+            ByteArrayResource resource = new ByteArrayResource(audioBytes) {
+                @Override
+                public String getFilename() {
+                    return "audio.wav";
+                }
+            };
+
+            MultipartBodyBuilder builder = new MultipartBodyBuilder();
+
+            builder.part("audio", resource);
+
+            this.webTestClient
+                    .post()
+                    .uri("/api/v1/voice/transcribe")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(BodyInserters.fromMultipartData(builder.build()))
+                    .exchange()
+                    .expectStatus().isBadRequest();
+
+
+        }
+    }
+
+
+    @WebFluxTest(controllers = VoiceController.class)
+    @Import({
+            SecurityConfig.class,
+            JwtAuthenticationFilter.class
+    })
+    @Nested
+    class UnauthorizedTests {
+
+        @Autowired
+        private WebTestClient webTestClient;
+
+        @MockitoBean
+        private JwtService jwtService;
+
+        @MockitoBean
+        private VoiceConversationService voiceConversationService;
+
+        @Test
+        @DisplayName("Test GET /api/v1/voice/status - Should return 401 without JWT token")
+        void testVoiceStatus_ShouldReturnUnauthorized() {
+
+            webTestClient.get()
+                    .uri("/api/v1/voice/status")
+                    .exchange()
+                    .expectStatus().isUnauthorized();
+        }
+
+        @Test
+        @DisplayName("Test POST /api/v1/voice/speak - Should return 401 without JWT token")
+        void testVoiceSpeak_ShouldReturnUnauthorized() {
+
+            webTestClient.post()
+                    .uri("/api/v1/voice/speak")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue("""
+                                                    {
+                                                    "text": "This is a text"
+                                                    }
+                            """)
+                    .exchange()
+                    .expectStatus().isUnauthorized();
+        }
+
+        @Test
+        @DisplayName("Test POST /api/v1/voice/transcribe - Should return 401 without JWT token")
+        void testVoiceTranscribe_ShouldReturnUnauthorized() {
+
+            byte[] audioBytes = new byte[]{1, 2, 3, 4};
+
+            ByteArrayResource resource = new ByteArrayResource(audioBytes) {
+                @Override
+                public String getFilename() {
+                    return "audio.wav";
+                }
+            };
+
+            MultipartBodyBuilder builder = new MultipartBodyBuilder();
+
+            builder.part("audio", resource);
+
+            this.webTestClient
+                    .post()
+                    .uri("/api/v1/voice/transcribe")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(BodyInserters.fromMultipartData(builder.build()))
+                    .exchange()
+                    .expectStatus().isUnauthorized();
+
+        }
+
+    }
+
+}

--- a/server/src/test/java/ai/jarvis/voice/WhisperTranscriptionServiceTest.java
+++ b/server/src/test/java/ai/jarvis/voice/WhisperTranscriptionServiceTest.java
@@ -212,6 +212,7 @@ class WhisperTranscriptionServiceTest {
                 .verifyComplete();
     }
 
+
     /**
      * Verifies that an explicit language is included
      * in the multipart request sent to Whisper.
@@ -223,11 +224,31 @@ class WhisperTranscriptionServiceTest {
         MultipartBodyBuilder builder =
                 serviceWithKey.buildMultipartBody(new byte[]{1, 2, 3}, "en");
 
-        assertThat(builder.build()).containsKey("language");
-        assertThat(builder.build().getFirst("language").getBody())
+        var parts = builder.build();
+
+        assertThat(parts).containsKey("language");
+        assertThat(parts.getFirst("language").getBody())
                 .isEqualTo("en");
     }
 
+
+    /**
+     * Verifies that the language field is omitted
+     * from the multipart body when language is null.
+     */
+    @Test
+    @DisplayName("multipart body omits language field when null")
+    void shouldOmitLanguageFromMultipartBodyWhenNull() {
+
+        var parts = serviceWithKey
+                .buildMultipartBody(
+                        new byte[]{1, 2, 3},
+                        null)
+                .build();
+
+        assertThat(parts)
+                .doesNotContainKey("language");
+    }
 
     /**
      * Verifies that whitespace surrounding

--- a/server/src/test/java/ai/jarvis/voice/WhisperTranscriptionServiceTest.java
+++ b/server/src/test/java/ai/jarvis/voice/WhisperTranscriptionServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -67,6 +68,11 @@ class WhisperTranscriptionServiceTest {
     private static final String MODEL =
             "whisper-large-v3-turbo";
 
+
+    /**
+     * Initializes mocked WebClient dependencies
+     * and Whisper service instances before each test.
+     */
     @BeforeEach
     void setUp() {
         // Wire builder BEFORE creating services
@@ -94,6 +100,11 @@ class WhisperTranscriptionServiceTest {
 
     // ── Guard tests ───────────────────────────────
 
+
+    /**
+     * Verifies that null audio is rejected
+     * with the EMPTY_AUDIO error code.
+     */
     @Test
     @DisplayName("transcribe() fails with EMPTY_AUDIO for null bytes")
     void shouldFailForNullAudio() {
@@ -107,6 +118,11 @@ class WhisperTranscriptionServiceTest {
                 .verify();
     }
 
+
+    /**
+     * Verifies that empty audio is rejected
+     * with the EMPTY_AUDIO error code.
+     */
     @Test
     @DisplayName("transcribe() fails with EMPTY_AUDIO for empty bytes")
     void shouldFailForEmptyAudio() {
@@ -120,6 +136,11 @@ class WhisperTranscriptionServiceTest {
                 .verify();
     }
 
+
+    /**
+     * Verifies that transcription fails
+     * when Whisper is not configured.
+     */
     @Test
     @DisplayName("transcribe() fails when no key configured")
     void shouldFailWhenNotConfigured() {
@@ -135,6 +156,11 @@ class WhisperTranscriptionServiceTest {
                 .verify();
     }
 
+
+    /**
+     * Verifies that language-specific transcription
+     * fails when Whisper is not configured.
+     */
     @Test
     @DisplayName("transcribe() with language fails when not configured")
     void shouldFailWithLanguageWhenNotConfigured() {
@@ -148,6 +174,11 @@ class WhisperTranscriptionServiceTest {
                 .verify();
     }
 
+
+    /**
+     * Verifies that a null language is accepted
+     * and audio validation still applies.
+     */
     @Test
     @DisplayName("transcribe() null language accepted (auto-detect)")
     void shouldAcceptNullLanguage() {
@@ -163,6 +194,11 @@ class WhisperTranscriptionServiceTest {
 
     // ── Success tests ─────────────────────────────
 
+
+    /**
+     * Verifies that transcription returns text
+     * when the provider responds successfully.
+     */
     @Test
     @DisplayName("transcribe() returns text on success")
     void shouldReturnTranscribedText() {
@@ -176,18 +212,27 @@ class WhisperTranscriptionServiceTest {
                 .verifyComplete();
     }
 
+    /**
+     * Verifies that an explicit language is included
+     * in the multipart request sent to Whisper.
+     */
     @Test
-    @DisplayName("transcribe() with language returns text on success")
-    void shouldReturnTranscribedTextWithLanguage() {
-        stubPostChain(Mono.just("Hello from Jarvis"));
+    @DisplayName("multipart body includes explicit language")
+    void shouldIncludeLanguageInMultipartBody() {
 
-        StepVerifier.create(
-                        serviceWithKey.transcribe(new byte[]{1, 2, 3, 4}, "en")
-                )
-                .expectNext("Hello from Jarvis")
-                .verifyComplete();
+        MultipartBodyBuilder builder =
+                serviceWithKey.buildMultipartBody(new byte[]{1, 2, 3}, "en");
+
+        assertThat(builder.build()).containsKey("language");
+        assertThat(builder.build().getFirst("language").getBody())
+                .isEqualTo("en");
     }
 
+
+    /**
+     * Verifies that whitespace surrounding
+     * a successful transcription is trimmed.
+     */
     @Test
     @DisplayName("transcribe() trims whitespace from response")
     void shouldTrimTranscribedText() {
@@ -203,6 +248,11 @@ class WhisperTranscriptionServiceTest {
                 .verifyComplete();
     }
 
+
+    /**
+     * Verifies that provider errors are mapped
+     * to TRANSCRIPTION_FAILED.
+     */
     @Test
     @DisplayName("transcribe() maps API error to TRANSCRIPTION_FAILED")
     void shouldMapApiErrorToVoiceException() {
@@ -222,6 +272,11 @@ class WhisperTranscriptionServiceTest {
                 .verify();
     }
 
+
+    /**
+     * Verifies that a blank provider response
+     * is mapped to TRANSCRIPTION_FAILED.
+     */
     @Test
     @DisplayName("transcribe() handles blank provider response gracefully")
     void shouldFailForBlankProviderResponse() {
@@ -239,6 +294,11 @@ class WhisperTranscriptionServiceTest {
 
     // ── isAvailable() tests ───────────────────────
 
+
+    /**
+     * Verifies that isAvailable returns false
+     * when Whisper is not configured.
+     */
     @Test
     @DisplayName("isAvailable() returns false when not configured")
     void shouldReturnFalseWhenNotConfigured() {
@@ -249,6 +309,11 @@ class WhisperTranscriptionServiceTest {
                 .verifyComplete();
     }
 
+
+    /**
+     * Verifies that isAvailable returns true
+     * when API responds.
+     */
     @Test
     @DisplayName("isAvailable() returns true when API responds")
     void shouldReturnTrueWhenApiResponds() {
@@ -261,6 +326,11 @@ class WhisperTranscriptionServiceTest {
                 .verifyComplete();
     }
 
+
+    /**
+     * Verifies that isAvailable returns false
+     * on connection error.
+     */
     @Test
     @DisplayName("isAvailable() returns false on connection error")
     void shouldReturnFalseOnConnectionError() {
@@ -276,6 +346,11 @@ class WhisperTranscriptionServiceTest {
 
     // ── getMode() tests ───────────────────────────
 
+
+    /**
+     * Verifies that a Groq URL reports
+     * the groq-cloud mode.
+     */
     @Test
     @DisplayName("getMode() returns cloud for cloud URL")
     void shouldReturnCloudModeForCloudUrl() {
@@ -283,6 +358,11 @@ class WhisperTranscriptionServiceTest {
                 .isEqualTo("groq-cloud");
     }
 
+
+    /**
+     * Verifies that a service without an API key
+     * reports the not-configured mode.
+     */
     @Test
     @DisplayName("getMode() returns not-configured when no key")
     void shouldReturnNotConfiguredWhenNoKey() {
@@ -290,6 +370,11 @@ class WhisperTranscriptionServiceTest {
                 .isEqualTo("not-configured");
     }
 
+
+    /**
+     * Verifies that a localhost Whisper instance
+     * reports the local-whisper mode.
+     */
     @Test
     @DisplayName("getMode() returns local for local URL")
     void shouldReturnLocalModeForLocalUrl() {
@@ -350,4 +435,6 @@ class WhisperTranscriptionServiceTest {
         when(responseSpec.bodyToMono(String.class))
                 .thenReturn(responseBody);
     }
+
+
 }

--- a/server/src/test/java/ai/jarvis/voice/WhisperTranscriptionServiceTest.java
+++ b/server/src/test/java/ai/jarvis/voice/WhisperTranscriptionServiceTest.java
@@ -177,6 +177,18 @@ class WhisperTranscriptionServiceTest {
     }
 
     @Test
+    @DisplayName("transcribe() with language returns text on success")
+    void shouldReturnTranscribedTextWithLanguage() {
+        stubPostChain(Mono.just("Hello from Jarvis"));
+
+        StepVerifier.create(
+                        serviceWithKey.transcribe(new byte[]{1, 2, 3, 4}, "en")
+                )
+                .expectNext("Hello from Jarvis")
+                .verifyComplete();
+    }
+
+    @Test
     @DisplayName("transcribe() trims whitespace from response")
     void shouldTrimTranscribedText() {
         // Whisper API often returns trailing newlines
@@ -209,6 +221,21 @@ class WhisperTranscriptionServiceTest {
                                         "TRANSCRIPTION_FAILED"))
                 .verify();
     }
+
+    @Test
+    @DisplayName("transcribe() handles blank provider response gracefully")
+    void shouldFailForBlankProviderResponse() {
+
+        stubPostChain(Mono.just("    "));
+
+        StepVerifier.create(serviceWithKey.transcribe(new byte[]{1, 2, 3, 4}))
+                .expectErrorMatches(error ->
+                        error instanceof VoiceException ve &&
+                                ve.getErrorCode().equals("TRANSCRIPTION_FAILED"))
+                .verify();
+
+    }
+
 
     // ── isAvailable() tests ───────────────────────
 


### PR DESCRIPTION
## What Does This PR Do?

Adds test coverage for the Voice API, including controller tests for status, text-to-speech, transcription, and unauthorized access.

Also extends `WhisperTranscriptionServiceTest` with coverage for language-specific transcription and blank provider responses.

---

## Related Issue

Closes #78

---

## Type of Change

* [ ] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📝 Documentation
* [ ] ♻️ Refactoring
* [x] 🧪 Tests
* [ ] 🔧 Maintenance / chore

---

## Testing

* [x] `./mvnw test` passes
* [ ] Tested with Ollama running locally
* [x] Tested on OS: Ubuntu
* [x] New tests added for this change

---

## Checklist

* [x] Code follows the project coding standards
* [x] I have reviewed my own changes
* [x] Documentation updated (if needed)
* [x] No secrets or API keys in the code
* [x] Conventional commit messages used
* [x] No breaking changes
  (or discussed in the issue first)

---

## Screenshots (if relevant)

Not applicable - test-only changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for authenticated and unauthenticated voice API requests.
  * Added validation for speech, transcription, status checks, blank inputs, empty audio, unavailable services, and provider failures.
  * Verified transcription requests correctly include an explicitly selected language or omit it when unspecified.
  * Added coverage for successful and empty transcription responses, improving confidence in voice feature behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->