### PR TITLE
feat(cli): add tool commands

### DIFF
--- a/server/src/main/java/ai/jarvis/cli/ToolCommands.java
+++ b/server/src/main/java/ai/jarvis/cli/ToolCommands.java
@@ -148,6 +148,9 @@ public class ToolCommands {
             return Double.valueOf(trimmed);
         }
         if (targetType == boolean.class || targetType == Boolean.class) {
+            if (!"true".equalsIgnoreCase(trimmed) && !"false".equalsIgnoreCase(trimmed)) {
+                throw new IllegalArgumentException("Boolean value must be true or false.");
+            }
             return Boolean.valueOf(trimmed);
         }
         throw new IllegalArgumentException("Unsupported parameter type: " + targetType.getName());

--- a/server/src/main/java/ai/jarvis/cli/ToolCommands.java
+++ b/server/src/main/java/ai/jarvis/cli/ToolCommands.java
@@ -1,0 +1,155 @@
+package ai.jarvis.cli;
+
+import ai.jarvis.tools.JarvisTool;
+import ai.jarvis.tools.ToolRegistry;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.shell.core.command.annotation.Command;
+import org.springframework.shell.core.command.annotation.Option;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+@Component
+public class ToolCommands {
+    private final CliStateManager state;
+    private final ToolRegistry toolRegistry;
+
+    public ToolCommands(CliStateManager state, ToolRegistry toolRegistry) {
+        this.state = state;
+        this.toolRegistry = toolRegistry;
+    }
+    @Command(
+            name = "tools",
+            description = "List all registered AI tools and methods"
+    )
+    public String tools() {
+        if (!state.isLoggedIn()) {
+            return "Not logged in. Type: login";
+        }
+        List<JarvisTool> tools = toolRegistry.getAll();
+
+        StringBuilder output = new StringBuilder();
+        output.append("\nAvailable Tools (").append(tools.size()).append(")\n");
+        output.append("---------------------------\n");
+
+        for (JarvisTool tool : tools) {
+            output.append("\n")
+                    .append(tool.getClass().getSimpleName())
+                    .append("\n");
+
+            Method[] methods = tool.getClass().getMethods();
+            for (Method method : methods) {
+                if (!method.isAnnotationPresent(Tool.class)) {
+                    continue;
+                }
+
+                output.append("  - ").append(method.getName()).append("(");
+                Class<?>[] parameterTypes = method.getParameterTypes();
+
+                for (int i = 0; i < parameterTypes.length; i++) {
+                    if (i > 0) {
+                        output.append(", ");
+                    }
+                    output.append(parameterTypes[i].getSimpleName());
+                }
+                output.append(")\n");
+            }
+        }
+        return output.toString();
+    }
+    @Command(
+            name = "tool-test",
+            description = "Test any registered tool method directly"
+    )
+    public String toolTest(
+            @Option(
+                    longName = "tool",
+                    shortName = 't',
+                    required = true,
+                    description = "Tool name, for example CalculatorTool"
+            )
+            String toolName,
+            @Option(
+                    longName = "method",
+                    shortName = 'm',
+                    required = true,
+                    description = "Tool method name"
+            )
+            String methodName,
+            @Option(
+                    longName = "input",
+                    shortName = 'i',
+                    required = false,
+                    defaultValue = "",
+                    description = "Comma-separated method arguments"
+            )
+            String input) {
+
+        if (!state.isLoggedIn()) {
+            return "Not logged in. Type: login";
+        }
+
+        JarvisTool selectedTool = null;
+        for (JarvisTool tool : toolRegistry.getAll()) {
+            if (toolName.equals(tool.getClass().getSimpleName())) {
+                selectedTool = tool;
+                break;
+            }
+        }
+        if (selectedTool == null) {
+            return "Unknown tool: "+toolName;
+        }
+        Method selectedMethod = null;
+        for (Method method : selectedTool.getClass().getMethods()) {
+            if (method.isAnnotationPresent(Tool.class)
+                    && methodName.equals(method.getName())) {
+                selectedMethod = method;
+                break;
+            }
+        }
+        if (selectedMethod == null) {
+            return "Unknown method: "+methodName;
+        }
+        try {
+            Class<?>[] parameterTypes = selectedMethod.getParameterTypes();
+            Object[] arguments = new Object[parameterTypes.length];
+            if (parameterTypes.length > 0) {
+                String[] values =  input.split("\\s*,\\s*");
+                if (parameterTypes.length != values.length) {
+                    return "Invalid input format";
+                }
+                for (int i = 0; i < parameterTypes.length; i++) {
+                    arguments[i] = convertValue(values[i], parameterTypes[i]);
+                }
+            }
+            Object result = selectedMethod.invoke(selectedTool, arguments);
+            if (result == null) {
+                return "Tool returned no result.";
+            }
+            return result.toString();
+        } catch (Exception e) {
+            return "Tool execution failed: " + e.getMessage();
+        }
+    }
+
+    private Object convertValue(String value, Class<?> targetType) {
+        String trimmed = value.trim();
+        if (targetType == String.class) {
+            return trimmed;
+        }
+        if (targetType == int.class || targetType == Integer.class) {
+            return Integer.valueOf(trimmed);
+        }
+        if (targetType == long.class || targetType == Long.class) {
+            return Long.valueOf(trimmed);
+        }
+        if (targetType == double.class || targetType == Double.class) {
+            return Double.valueOf(trimmed);
+        }
+        if (targetType == boolean.class || targetType == Boolean.class) {
+            return Boolean.valueOf(trimmed);
+        }
+        throw new IllegalArgumentException("Unsupported parameter type: " + targetType.getName());
+    }
+}

--- a/server/src/main/java/ai/jarvis/cli/ToolCommands.java
+++ b/server/src/main/java/ai/jarvis/cli/ToolCommands.java
@@ -2,6 +2,8 @@ package ai.jarvis.cli;
 
 import ai.jarvis.tools.JarvisTool;
 import ai.jarvis.tools.ToolRegistry;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.shell.core.command.annotation.Command;
 import org.springframework.shell.core.command.annotation.Option;
@@ -10,6 +12,7 @@ import org.springframework.stereotype.Component;
 import java.lang.reflect.Method;
 import java.util.List;
 
+@Slf4j
 @Component
 public class ToolCommands {
     private final CliStateManager state;
@@ -38,7 +41,7 @@ public class ToolCommands {
                     .append(tool.getClass().getSimpleName())
                     .append("\n");
 
-            Method[] methods = tool.getClass().getMethods();
+            Method[] methods = tool.getClass().getDeclaredMethods();
             for (Method method : methods) {
                 if (!method.isAnnotationPresent(Tool.class)) {
                     continue;
@@ -98,10 +101,10 @@ public class ToolCommands {
             }
         }
         if (selectedTool == null) {
-            return "Unknown tool: "+toolName;
+            return "Unknown tool: "+ toolName + ". Run 'tools' to see available tools and methods.";
         }
         Method selectedMethod = null;
-        for (Method method : selectedTool.getClass().getMethods()) {
+        for (Method method : selectedTool.getClass().getDeclaredMethods()) {
             if (method.isAnnotationPresent(Tool.class)
                     && methodName.equals(method.getName())) {
                 selectedMethod = method;
@@ -109,7 +112,7 @@ public class ToolCommands {
             }
         }
         if (selectedMethod == null) {
-            return "Unknown method: "+methodName;
+            return "Unknown method: " + methodName + ". Run 'tools' to see available tools and methods.";
         }
         try {
             Class<?>[] parameterTypes = selectedMethod.getParameterTypes();

--- a/server/src/main/java/ai/jarvis/cli/ToolCommands.java
+++ b/server/src/main/java/ai/jarvis/cli/ToolCommands.java
@@ -10,6 +10,7 @@ import org.springframework.shell.core.command.annotation.Option;
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.List;
 
 @Slf4j
@@ -43,7 +44,8 @@ public class ToolCommands {
 
             Method[] methods = tool.getClass().getDeclaredMethods();
             for (Method method : methods) {
-                if (!method.isAnnotationPresent(Tool.class)) {
+                if (!method.isAnnotationPresent(Tool.class)
+                        || !Modifier.isPublic(method.getModifiers())) {
                     continue;
                 }
 
@@ -106,7 +108,8 @@ public class ToolCommands {
         Method selectedMethod = null;
         for (Method method : selectedTool.getClass().getDeclaredMethods()) {
             if (method.isAnnotationPresent(Tool.class)
-                    && methodName.equals(method.getName())) {
+                    && methodName.equals(method.getName())
+                    && Modifier.isPublic(method.getModifiers())) {
                 selectedMethod = method;
                 break;
             }

--- a/server/src/test/java/ai/jarvis/cli/ToolCommandsTest.java
+++ b/server/src/test/java/ai/jarvis/cli/ToolCommandsTest.java
@@ -76,5 +76,20 @@ class ToolCommandsTest {
         String result = toolCommands.toolTest("DateTimeTool", "getCurrentDateTime", "");
         assertThat(result).isNotBlank();
     }
-
+    @Test
+    @DisplayName("tool-test should point to tools command for unknown tool")
+    void toolTestShouldPointToToolsCommandForUnknownTool() {
+        when(state.isLoggedIn()).thenReturn(true);
+        String result = toolCommands.toolTest("UnknownTool", "calculate", "2847 * 391");
+        assertThat(result).contains("Unknown tool: UnknownTool")
+                .contains("Run 'tools'");
+    }
+    @Test
+    @DisplayName("tool-test should point to tools command for unknown method")
+    void toolTestShouldPointToToolsCommandForUnknownMethod() {
+        when(state.isLoggedIn()).thenReturn(true);
+        String result = toolCommands.toolTest("CalculatorTool", "unknownMethod", "1 + 1");
+        assertThat(result).contains("Unknown method: unknownMethod")
+                .contains("Run 'tools'");
+    }
 }

--- a/server/src/test/java/ai/jarvis/cli/ToolCommandsTest.java
+++ b/server/src/test/java/ai/jarvis/cli/ToolCommandsTest.java
@@ -1,0 +1,80 @@
+package ai.jarvis.cli;
+
+import ai.jarvis.tools.ToolRegistry;
+import ai.jarvis.tools.builtin.CalculatorTool;
+import ai.jarvis.tools.builtin.DateTimeTool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ToolCommands Unit Tests")
+class ToolCommandsTest {
+    @Mock
+    private CliStateManager state;
+
+    private ToolCommands toolCommands;
+
+    @BeforeEach
+    void setUp() {
+        CalculatorTool calculatorTool = new CalculatorTool();
+        DateTimeTool dateTimeTool = new DateTimeTool();
+        ToolRegistry toolRegistry = new ToolRegistry(List.of(calculatorTool, dateTimeTool));
+        toolCommands = new ToolCommands(state, toolRegistry);
+    }
+    @Test
+    @DisplayName("tools should require login")
+    void toolsShouldRequireLogin() {
+        when(state.isLoggedIn()).thenReturn(false);
+        String result = toolCommands.tools();
+        assertThat(result).contains("Not logged in");
+    }
+    @Test
+    @DisplayName("tools should list registered tools and methods")
+    void toolsShouldListRegisteredToolsAndMethods() {
+        when(state.isLoggedIn()).thenReturn(true);
+        String result = toolCommands.tools();
+        assertThat(result).contains("Available Tools (2)");
+        assertThat(result).contains("CalculatorTool")
+                .contains("calculate")
+                .contains("calculatePercentage")
+                .contains("squareRoot");
+        assertThat(result).contains("DateTimeTool")
+                .contains("getCurrentDateTime")
+                .contains("getCurrentTimeInZone")
+                .contains("getCurrentDate")
+                .contains("listTimezonesForRegion");
+
+    }
+
+    @Test
+    @DisplayName("tool-test should require login")
+    void toolTestShouldRequireLogin() {
+        when(state.isLoggedIn()).thenReturn(false);
+        String result = toolCommands.toolTest("CalculatorTool", "calculate", "1 + 1");
+        assertThat(result).contains("Not logged in");
+    }
+    @Test
+    @DisplayName("tool-test should call calculator")
+    void toolTestShouldCallCalculator() {
+        when(state.isLoggedIn()).thenReturn(true);
+        String result = toolCommands.toolTest("CalculatorTool", "calculate", "2847 * 391");
+        assertThat(result).contains("2847 * 391").contains("1,113,177");
+    }
+    @Test
+    @DisplayName("tool-test should call date time method without input")
+    void toolTestShouldCallDateTimeWithoutInput() {
+        when(state.isLoggedIn()).thenReturn(true);
+        String result = toolCommands.toolTest("DateTimeTool", "getCurrentDateTime", "");
+        assertThat(result).isNotBlank();
+    }
+
+}


### PR DESCRIPTION
## What Does This PR Do?

Adds CLI commands for listing and test registered Jarvis tools.

## Implemented Commands

The `tools` command lists all registered tools and their `@Tool` methods.

The `tool-test` command uses an explicit `--tool`, `--method`, and `--input` interface:

```text
tool-test --tool <tool> --method <method> --input <input>
Examples:
tool-test --tool CalculatorTool --method calculate --input "2847 * 391"
tool-test --tool WeatherTool --method getWeather --input "Kathmandu"
tool-test --tool DateTimeTool --method getCurrentDateTime
The explicit --method option was added because a single tool can expose multiple @Tool methods. This makes method selection unambiguous and allows each registered tool method to be tested directly from the CLI.
Both commands require the user to be logged in. Command and option help descriptions have also been added.
```
---

## Related Issue

Closes #[66]

---

## Type of Change

* [-] ✨ New feature
* [-] 🧪 Tests

---

## Testing

* [-] `./mvnw test` passes
* [ ] Tested with Ollama running locally
* [-] Tested on OS: Windows
* [-] New tests added for this change

---

## Checklist

* [-] Code follows the project coding standards
* [-] I have reviewed my own changes
* [-] No secrets or API keys in the code
* [-] Conventional commit messages used
* [-] No breaking changes
  (or discussed in the issue first)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to list available tools and their callable methods.
  * Added a tool-testing command that accepts input values, invokes supported methods, and displays results.
  * Added clear feedback for authentication requirements and invalid tool, method, or input selections.

* **Tests**
  * Added coverage for authentication checks, tool listings, calculator operations, and date-time commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->